### PR TITLE
Address zoom animation issues arising from standard niri actions (e.g. close overview with click, pressing enter etc.)

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1633,6 +1633,18 @@ mod tests {
                         ),
                     },
                 ),
+                overview_zoom: OverviewZoomAnim(
+                    Animation {
+                        off: false,
+                        kind: Spring(
+                            SpringParams {
+                                damping_ratio: 1.0,
+                                stiffness: 800,
+                                epsilon: 0.0001,
+                            },
+                        ),
+                    },
+                ),
                 recent_windows_close: RecentWindowsCloseAnim(
                     Animation {
                         off: true,
@@ -1699,6 +1711,7 @@ mod tests {
                         a: 0.3137255,
                     },
                 },
+                zoom_presets: None,
             },
             environment: Environment(
                 [

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4603,9 +4603,8 @@ impl<W: LayoutElement> Layout<W> {
 
         // Reset zoom to config default when closing overview.
         if !self.overview_open {
-            let default_zoom = self.options.overview.zoom;
             for monitor in self.monitors_mut() {
-                monitor.reset_overview_zoom(default_zoom);
+                monitor.reset_overview_zoom();
             }
         }
 

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1418,8 +1418,7 @@ impl<W: LayoutElement> Monitor<W> {
 
     /// Reset zoom to config default - call when overview closes.
     /// This is instant (no animation) since the overview is closing.
-    pub fn reset_overview_zoom(&mut self, default_zoom: f64) {
-        self.overview_zoom_target = default_zoom;
+    pub fn reset_overview_zoom(&mut self) {
         self.overview_zoom_anim = None;
         self.overview_zoom_preset_idx = 0;
     }
@@ -1440,8 +1439,7 @@ impl<W: LayoutElement> Monitor<W> {
         }
         let len = presets.len();
         if reverse {
-            self.overview_zoom_preset_idx =
-                (self.overview_zoom_preset_idx + len - 1) % len;
+            self.overview_zoom_preset_idx = (self.overview_zoom_preset_idx + len - 1) % len;
         } else {
             self.overview_zoom_preset_idx = (self.overview_zoom_preset_idx + 1) % len;
         }


### PR DESCRIPTION
Hey @barrulus.

This PR fixes an animation issue for standard Niri overview actions (e.g. when clicking or pressing "enter" when in overview) as mentioned in https://github.com/niri-wm/niri/pull/3194.

~~Overview.zoom (which is the "default" zoom) is now private and access is by a "zoom" function which takes into account overview zoom presets.  That is, the current `overview_zoom_preset_idx` can be provided (as `Option<usize`) to the `zoom()` function.  When this is provided, the "default" zoom becomes the actual zoom level from the presets - naturally fitting into niri's overview actions and animations.  When presets don't exist, the standard Overview.zoom value is returned as normal.~~

~~This should avoid any "custom" code or specific implementations work around overview default zoom when addressing niri standard actions when using zoom presets etc.~~

_Following this down the rabbit hole led to quite a simple fix..._