### PR TITLE
Feature/dynamic overview add option to use default zoom (instead of last used zoom preset) for standard niri overview actions (e.g. hot-corner or keybind)

### DIFF
--- a/docs/wiki/Configuration:-Miscellaneous.md
+++ b/docs/wiki/Configuration:-Miscellaneous.md
@@ -253,12 +253,12 @@ overview {
 Define a list of zoom levels to cycle through using the `overview-zoom-cycle` action.
 If not set or empty, the cycle action does nothing.
 
-Setting option `zoom-use-last-preset` to `true` allows standard niri overview actions (e.g. entering overview via hot-corner or keybind) to start at the "last used" zoom preset.  The default setting of `false` starts overview at the niri's overview `zoom` value (0.5 by default).
+Option `zoom-remember-last` to `true` allows standard niri overview actions (e.g. entering overview via hot-corner or keybind) to start at the "last used" zoom preset.  The default setting of `false` starts overview at the niri's overview `zoom` value.
 
 ```kdl
 overview {
     zoom-presets 0.5 0.25 0.1
-    zoom-use-last-preset true
+    zoom-remember-last true
 }
 ```
 

--- a/docs/wiki/Configuration:-Miscellaneous.md
+++ b/docs/wiki/Configuration:-Miscellaneous.md
@@ -253,7 +253,7 @@ overview {
 Define a list of zoom levels to cycle through using the `overview-zoom-cycle` action.
 If not set or empty, the cycle action does nothing.
 
-Option `zoom-remember-last` to `true` allows standard niri overview actions (e.g. entering overview via hot-corner or keybind) to start at the "last used" zoom preset.  The default setting of `false` starts overview at the niri's overview `zoom` value.
+Option `zoom-remember-last` controls the starting "zoom" behaviour for standard niri overview actions (e.g. entering overview via hot-corner or keybind).  The default value of `true` causes overview to always "start" at the _last used_ zoom level.  Setting this to `false` causes niri to always open overview at the defined `overview { zoom }` value for standard niri overview actions.
 
 ```kdl
 overview {

--- a/docs/wiki/Configuration:-Miscellaneous.md
+++ b/docs/wiki/Configuration:-Miscellaneous.md
@@ -253,9 +253,12 @@ overview {
 Define a list of zoom levels to cycle through using the `overview-zoom-cycle` action.
 If not set or empty, the cycle action does nothing.
 
+Setting option `zoom-use-last-preset` to `true` allows standard niri overview actions (e.g. entering overview via hot-corner or keybind) to start at the "last used" zoom preset.  The default setting of `false` starts overview at the niri's overview `zoom` value (0.5 by default).
+
 ```kdl
 overview {
     zoom-presets 0.5 0.25 0.1
+    zoom-use-last-preset true
 }
 ```
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1712,6 +1712,7 @@ mod tests {
                     },
                 },
                 zoom_presets: None,
+                zoom_use_last_preset: false,
             },
             environment: Environment(
                 [

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1712,7 +1712,7 @@ mod tests {
                     },
                 },
                 zoom_presets: None,
-                zoom_remember_last: false,
+                zoom_remember_last: true,
             },
             environment: Environment(
                 [

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1712,7 +1712,7 @@ mod tests {
                     },
                 },
                 zoom_presets: None,
-                zoom_use_last_preset: false,
+                zoom_remember_last: false,
             },
             environment: Environment(
                 [

--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -135,7 +135,7 @@ impl Default for Overview {
             backdrop_color: DEFAULT_BACKDROP_COLOR,
             workspace_shadow: WorkspaceShadow::default(),
             zoom_presets: None,
-            zoom_remember_last: false,
+            zoom_remember_last: true,
         }
     }
 }

--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -125,6 +125,7 @@ pub struct Overview {
     pub workspace_shadow: WorkspaceShadow,
     /// Optional zoom presets for cycling. If None/empty, zoom cycling is disabled.
     pub zoom_presets: Option<Vec<f64>>,
+    pub zoom_use_last_preset: bool,
 }
 
 impl Default for Overview {
@@ -134,6 +135,7 @@ impl Default for Overview {
             backdrop_color: DEFAULT_BACKDROP_COLOR,
             workspace_shadow: WorkspaceShadow::default(),
             zoom_presets: None,
+            zoom_use_last_preset: false,
         }
     }
 }
@@ -153,6 +155,8 @@ pub struct OverviewPart {
     pub workspace_shadow: Option<WorkspaceShadowPart>,
     #[knuffel(child)]
     pub zoom_presets: Option<ZoomPresets>,
+    #[knuffel(child)]
+    pub zoom_use_last_preset: Option<Flag>,
 }
 
 impl MergeWith<OverviewPart> for Overview {
@@ -162,6 +166,7 @@ impl MergeWith<OverviewPart> for Overview {
         if let Some(presets) = &part.zoom_presets {
             self.zoom_presets = Some(presets.0.clone());
         }
+        merge!((self, part), zoom_use_last_preset);
     }
 }
 

--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -125,7 +125,7 @@ pub struct Overview {
     pub workspace_shadow: WorkspaceShadow,
     /// Optional zoom presets for cycling. If None/empty, zoom cycling is disabled.
     pub zoom_presets: Option<Vec<f64>>,
-    pub zoom_use_last_preset: bool,
+    pub zoom_remember_last: bool,
 }
 
 impl Default for Overview {
@@ -135,7 +135,7 @@ impl Default for Overview {
             backdrop_color: DEFAULT_BACKDROP_COLOR,
             workspace_shadow: WorkspaceShadow::default(),
             zoom_presets: None,
-            zoom_use_last_preset: false,
+            zoom_remember_last: false,
         }
     }
 }
@@ -156,7 +156,7 @@ pub struct OverviewPart {
     #[knuffel(child)]
     pub zoom_presets: Option<ZoomPresets>,
     #[knuffel(child)]
-    pub zoom_use_last_preset: Option<Flag>,
+    pub zoom_remember_last: Option<Flag>,
 }
 
 impl MergeWith<OverviewPart> for Overview {
@@ -166,7 +166,7 @@ impl MergeWith<OverviewPart> for Overview {
         if let Some(presets) = &part.zoom_presets {
             self.zoom_presets = Some(presets.0.clone());
         }
-        merge!((self, part), zoom_use_last_preset);
+        merge!((self, part), zoom_remember_last);
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2272,7 +2272,7 @@ impl State {
                 self.niri.stop_cast(CastSessionId::from(session_id));
             }
             Action::ToggleOverview => {
-                self.niri.layout.toggle_overview();
+                self.niri.layout.toggle_overview(None);
                 self.niri.queue_redraw_all();
             }
             Action::OpenOverview => {
@@ -2728,7 +2728,7 @@ impl State {
                     .with_grab(|_, grab| grab_allows_hot_corner(grab))
                     .unwrap_or(true)
             {
-                self.niri.layout.toggle_overview();
+                self.niri.layout.toggle_overview(None);
             }
             self.niri.pointer_inside_hot_corner = true;
         }
@@ -2819,7 +2819,7 @@ impl State {
                     .with_grab(|_, grab| grab_allows_hot_corner(grab))
                     .unwrap_or(true)
             {
-                self.niri.layout.toggle_overview();
+                self.niri.layout.toggle_overview(None);
             }
             self.niri.pointer_inside_hot_corner = true;
         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2272,7 +2272,7 @@ impl State {
                 self.niri.stop_cast(CastSessionId::from(session_id));
             }
             Action::ToggleOverview => {
-                self.niri.layout.toggle_overview(None);
+                self.niri.layout.toggle_overview();
                 self.niri.queue_redraw_all();
             }
             Action::OpenOverview => {
@@ -2728,7 +2728,7 @@ impl State {
                     .with_grab(|_, grab| grab_allows_hot_corner(grab))
                     .unwrap_or(true)
             {
-                self.niri.layout.toggle_overview(None);
+                self.niri.layout.toggle_overview();
             }
             self.niri.pointer_inside_hot_corner = true;
         }
@@ -2819,7 +2819,7 @@ impl State {
                     .with_grab(|_, grab| grab_allows_hot_corner(grab))
                     .unwrap_or(true)
             {
-                self.niri.layout.toggle_overview(None);
+                self.niri.layout.toggle_overview();
             }
             self.niri.pointer_inside_hot_corner = true;
         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2300,7 +2300,7 @@ impl State {
                         monitor.set_zoom_target_no_anim(presets[0]);
                         monitor.set_zoom_preset_idx(0);
                     }
-                    self.niri.layout.open_overview();
+                    self.niri.layout.open_overview_preserving_zoom();
                 } else {
                     for monitor in self.niri.layout.monitors_mut() {
                         monitor.cycle_overview_zoom(&presets, reverse, anim_config);
@@ -2373,7 +2373,7 @@ impl State {
                         monitor.set_zoom_target_no_anim(max_preset);
                         monitor.set_zoom_preset_idx(max_idx);
                     }
-                    self.niri.layout.open_overview();
+                    self.niri.layout.open_overview_preserving_zoom();
                 } else {
                     for monitor in self.niri.layout.monitors_mut() {
                         monitor.overview_zoom_out(&presets, anim_config);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4605,7 +4605,7 @@ impl<W: LayoutElement> Layout<W> {
     pub fn toggle_overview_with_zoom(&mut self, zoom: Option<f64>) {
         // if not opened (and will be opening), set zoom target from provided
         // zoom parameter (default to `options.overview.zoom`).
-        let use_last_preset = self.options.overview.zoom_use_last_preset;
+        let use_last_preset = self.options.overview.zoom_remember_last;
         if !self.overview_open && !use_last_preset {
             // set zoom factor if opening
             let zoom: f64 = zoom.unwrap_or(self.options.overview.zoom);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4614,7 +4614,6 @@ impl<W: LayoutElement> Layout<W> {
         }
 
         if self.overview_open {
-            // Reset zoom to config default when closing overview.
             for monitor in self.monitors_mut() {
                 monitor.reset_overview_zoom();
             }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4601,14 +4601,16 @@ impl<W: LayoutElement> Layout<W> {
     pub fn toggle_overview(&mut self, zoom:Option<f64>) {        
         // if not opened (and will be opening), set zoom target from provided
         // zoom parameter (default to `options.overview.zoom`).
-        if !self.overview_open {
+        let use_last_preset = self.options.overview.zoom_use_last_preset;
+        if !self.overview_open && !use_last_preset {
             // set zoom factor if opening
             let zoom: f64 = zoom.unwrap_or(self.options.overview.zoom);
             for monitor in self.monitors_mut() {
                 monitor.set_zoom_target_no_anim(zoom);
             }
         }
-        else {
+        
+        if self.overview_open {
             // Reset zoom to config default when closing overview.
             for monitor in self.monitors_mut() {
                 monitor.reset_overview_zoom();

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4605,8 +4605,7 @@ impl<W: LayoutElement> Layout<W> {
     pub fn toggle_overview_with_zoom(&mut self, zoom: Option<f64>) {
         // if not opened (and will be opening), set zoom target from provided
         // zoom parameter (default to `options.overview.zoom`).
-        let use_last_preset = self.options.overview.zoom_remember_last;
-        if !self.overview_open && !use_last_preset {
+        if !self.overview_open && !self.options.overview.zoom_remember_last {
             // set zoom factor if opening
             let zoom: f64 = zoom.unwrap_or(self.options.overview.zoom);
             for monitor in self.monitors_mut() {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4641,6 +4641,15 @@ impl<W: LayoutElement> Layout<W> {
             return false;
         }
 
+        self.toggle_overview();
+        true
+    }
+
+    pub fn open_overview_preserving_zoom(&mut self) -> bool {
+        if self.overview_open {
+            return false;
+        }
+
         self.toggle_overview_with_zoom(self.active_monitor_ref().map(|m| m.overview_zoom_target()));
         true
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4598,7 +4598,11 @@ impl<W: LayoutElement> Layout<W> {
         }
     }
 
-    pub fn toggle_overview(&mut self, zoom:Option<f64>) {        
+    pub fn toggle_overview(&mut self) {    
+        self.toggle_overview_with_zoom(None);
+    }
+
+    pub fn toggle_overview_with_zoom(&mut self, zoom:Option<f64>) {        
         // if not opened (and will be opening), set zoom target from provided
         // zoom parameter (default to `options.overview.zoom`).
         let use_last_preset = self.options.overview.zoom_use_last_preset;
@@ -4637,7 +4641,7 @@ impl<W: LayoutElement> Layout<W> {
             return false;
         }
 
-        self.toggle_overview(self
+        self.toggle_overview_with_zoom(self
             .active_monitor_ref()
             .map(|m| m.overview_zoom_target()));
         true
@@ -4648,7 +4652,7 @@ impl<W: LayoutElement> Layout<W> {
             return false;
         }
 
-        self.toggle_overview(None);
+        self.toggle_overview();
         true
     }
 
@@ -4689,7 +4693,7 @@ impl<W: LayoutElement> Layout<W> {
         if let Some(mon) = self.active_monitor() {
             mon.activate_workspace_with_anim_config(ws_idx, Some(config));
         }
-        self.toggle_overview(None);
+        self.toggle_overview();
     }
 
     pub fn start_open_animation_for_window(&mut self, window: &W::Id) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4598,16 +4598,24 @@ impl<W: LayoutElement> Layout<W> {
         }
     }
 
-    pub fn toggle_overview(&mut self) {
-        self.overview_open = !self.overview_open;
-
-        // Reset zoom to config default when closing overview.
+    pub fn toggle_overview(&mut self, zoom:Option<f64>) {        
+        // if not opened (and will be opening), set zoom target from provided
+        // zoom parameter (default to `options.overview.zoom`).
         if !self.overview_open {
+            // set zoom factor if opening
+            let zoom: f64 = zoom.unwrap_or(self.options.overview.zoom);
+            for monitor in self.monitors_mut() {
+                monitor.set_zoom_target_no_anim(zoom);
+            }
+        }
+        else {
+            // Reset zoom to config default when closing overview.
             for monitor in self.monitors_mut() {
                 monitor.reset_overview_zoom();
             }
         }
 
+        self.overview_open = !self.overview_open;
         let from = self.overview_progress.take().map_or(0., |p| p.value());
         let to = if self.overview_open { 1. } else { 0. };
 
@@ -4627,7 +4635,9 @@ impl<W: LayoutElement> Layout<W> {
             return false;
         }
 
-        self.toggle_overview();
+        self.toggle_overview(self
+            .active_monitor_ref()
+            .map(|m| m.overview_zoom_target()));
         true
     }
 
@@ -4636,7 +4646,7 @@ impl<W: LayoutElement> Layout<W> {
             return false;
         }
 
-        self.toggle_overview();
+        self.toggle_overview(None);
         true
     }
 
@@ -4677,7 +4687,7 @@ impl<W: LayoutElement> Layout<W> {
         if let Some(mon) = self.active_monitor() {
             mon.activate_workspace_with_anim_config(ws_idx, Some(config));
         }
-        self.toggle_overview();
+        self.toggle_overview(None);
     }
 
     pub fn start_open_animation_for_window(&mut self, window: &W::Id) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4598,11 +4598,11 @@ impl<W: LayoutElement> Layout<W> {
         }
     }
 
-    pub fn toggle_overview(&mut self) {    
+    pub fn toggle_overview(&mut self) {
         self.toggle_overview_with_zoom(None);
     }
 
-    pub fn toggle_overview_with_zoom(&mut self, zoom:Option<f64>) {        
+    pub fn toggle_overview_with_zoom(&mut self, zoom: Option<f64>) {
         // if not opened (and will be opening), set zoom target from provided
         // zoom parameter (default to `options.overview.zoom`).
         let use_last_preset = self.options.overview.zoom_use_last_preset;
@@ -4613,7 +4613,7 @@ impl<W: LayoutElement> Layout<W> {
                 monitor.set_zoom_target_no_anim(zoom);
             }
         }
-        
+
         if self.overview_open {
             // Reset zoom to config default when closing overview.
             for monitor in self.monitors_mut() {
@@ -4641,9 +4641,7 @@ impl<W: LayoutElement> Layout<W> {
             return false;
         }
 
-        self.toggle_overview_with_zoom(self
-            .active_monitor_ref()
-            .map(|m| m.overview_zoom_target()));
+        self.toggle_overview_with_zoom(self.active_monitor_ref().map(|m| m.overview_zoom_target()));
         true
     }
 

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1463,7 +1463,10 @@ impl<W: LayoutElement> Monitor<W> {
 
         if let Some(new_target) = next {
             // Update preset index to match
-            if let Some(idx) = presets.iter().position(|&p| (p - new_target).abs() < 0.0001) {
+            if let Some(idx) = presets
+                .iter()
+                .position(|&p| (p - new_target).abs() < 0.0001)
+            {
                 self.overview_zoom_preset_idx = idx;
             }
             self.animate_zoom_to(new_target, config);
@@ -1486,7 +1489,10 @@ impl<W: LayoutElement> Monitor<W> {
 
         if let Some(new_target) = next {
             // Update preset index to match
-            if let Some(idx) = presets.iter().position(|&p| (p - new_target).abs() < 0.0001) {
+            if let Some(idx) = presets
+                .iter()
+                .position(|&p| (p - new_target).abs() < 0.0001)
+            {
                 self.overview_zoom_preset_idx = idx;
             }
             self.animate_zoom_to(new_target, config);

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -3732,6 +3732,96 @@ fn workspace_render_geo_at_fractional_scale() {
     );
 }
 
+fn layout_with_overview_zoom(zoom: f64, remember_last: bool) -> Layout<TestWindow> {
+    let options = Options {
+        overview: niri_config::Overview {
+            zoom,
+            zoom_remember_last: remember_last,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut layout = Layout::with_options(Clock::with_time(Duration::ZERO), options);
+    Op::AddOutput(1).apply(&mut layout);
+    layout
+}
+
+fn zoom_target(layout: &Layout<TestWindow>) -> f64 {
+    layout.active_monitor_ref().unwrap().overview_zoom_target()
+}
+
+#[test]
+fn overview_remembers_last_zoom_by_default() {
+    let mut layout = layout_with_overview_zoom(0.5, true);
+
+    layout.toggle_overview();
+    layout
+        .active_monitor()
+        .unwrap()
+        .set_zoom_target_no_anim(0.3);
+    layout.toggle_overview(); // close
+    layout.toggle_overview(); // reopen
+
+    assert_eq!(
+        zoom_target(&layout),
+        0.3,
+        "with zoom-remember-last, the parked zoom survives close/reopen"
+    );
+}
+
+#[test]
+fn overview_uses_config_zoom_when_remember_last_disabled() {
+    // Both standard entry points must agree: toggle_overview (hot corner and
+    // the toggle-overview bind) and open_overview (the open-overview bind).
+    for (name, open) in [
+        (
+            "toggle_overview",
+            &Layout::toggle_overview as &dyn Fn(&mut _),
+        ),
+        ("open_overview", &|l: &mut Layout<TestWindow>| {
+            l.open_overview();
+        }),
+    ] {
+        let mut layout = layout_with_overview_zoom(0.5, false);
+
+        layout.toggle_overview();
+        layout
+            .active_monitor()
+            .unwrap()
+            .set_zoom_target_no_anim(0.3);
+        layout.toggle_overview(); // close
+
+        open(&mut layout);
+
+        assert_eq!(
+            zoom_target(&layout),
+            0.5,
+            "{name} must start at the configured overview zoom, not the parked 0.3"
+        );
+    }
+}
+
+#[test]
+fn zoom_preset_auto_open_keeps_its_own_zoom() {
+    // The zoom-preset actions pick a zoom and then auto-open; that choice must
+    // survive regardless of how zoom-remember-last is set.
+    for remember_last in [true, false] {
+        let mut layout = layout_with_overview_zoom(0.5, remember_last);
+
+        layout
+            .active_monitor()
+            .unwrap()
+            .set_zoom_target_no_anim(0.1);
+        layout.open_overview_preserving_zoom();
+
+        assert_eq!(
+            zoom_target(&layout),
+            0.1,
+            "preset zoom must survive auto-open (zoom_remember_last = {remember_last})"
+        );
+    }
+}
+
 fn parent_id_causes_loop(layout: &Layout<TestWindow>, id: usize, mut parent_id: usize) -> bool {
     if parent_id == id {
         return true;

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1615,7 +1615,7 @@ impl Op {
                 layout.interactive_resize_end(&window);
             }
             Op::ToggleOverview => {
-                layout.toggle_overview();
+                layout.toggle_overview(None);
             }
             Op::UpdateConfig { layout_config } => {
                 let options = Options {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1615,7 +1615,7 @@ impl Op {
                 layout.interactive_resize_end(&window);
             }
             Op::ToggleOverview => {
-                layout.toggle_overview(None);
+                layout.toggle_overview();
             }
             Op::UpdateConfig { layout_config } => {
                 let options = Options {


### PR DESCRIPTION
This PR address the behaviour note mentioned here: https://github.com/niri-wm/niri/pull/3194#issuecomment-5184967824.

That is, it adds an option `zoom-use-last-preset` (which defaults to true) to control this behaviour.  Setting to `true` allows standard niri overview actions (e.g. activate by hot-corner or keybind) to use the last active zoom preset (which some of us prefer).  Setting to `false` (the default) causes overview to use niri's `zoom` setting (which is 0.5 by default) - which others may prefer.

Zoom preset behaviours are unaffected and function as designed.

<img width="261" height="117" alt="image" src="https://github.com/user-attachments/assets/889393bb-ad23-4203-80c8-f231876ddd6d" />
