### PR TITLE
[hidden workspaces] unhide_workspace_by_id: don't remove/reinsert workspace if it isn't actually a hidden workspace

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1548,6 +1548,11 @@ impl<W: LayoutElement> Layout<W> {
             MonitorSet::NoOutputs { workspaces } => {
                 for (idx, ws) in workspaces.iter_mut().enumerate() {
                     if ws.id() == id {
+                        // Unnaming removes the only way to unhide this workspace later
+                        // (unhide/toggle-visibility both look workspaces up by name), so
+                        // it must not be left hidden or pending a hide-on-switch-away.
+                        ws.hidden = false;
+                        ws.needs_hidden = false;
                         ws.unname();
 
                         // Clean up empty workspaces.

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -941,12 +941,12 @@ impl<W: LayoutElement> Monitor<W> {
         ws.hidden = false;
         ws.needs_hidden = needs_hidden;
         ws.original_idx = None;
-        // The vec may have shrunk (other workspaces emptied out and were cleaned up)
-        // while this one stayed hidden, so original_idx can now be stale and past
-        // the end. Clamp it or insert_workspace() panics.
-        let original_idx = original_idx.min(self.workspaces.len());
-        self.insert_workspace(ws, original_idx, false);
-        return Some(original_idx);
+        // original_idx was recorded at hide time and can now be stale (the vec may
+        // have shrunk while this workspace stayed hidden, or grown a new hidden
+        // block ahead of it). insert_workspace() clamps it to a safe position and
+        // returns where the workspace actually landed.
+        let final_idx = self.insert_workspace(ws, original_idx, false);
+        return Some(final_idx);
     }
 
     pub fn hide_workspace_by_name(&mut self, name: &str) {
@@ -1042,9 +1042,18 @@ impl<W: LayoutElement> Monitor<W> {
         self.clean_up_workspaces();
     }
 
-    pub fn insert_workspace(&mut self, mut ws: Workspace<W>, mut idx: usize, activate: bool) {
+    // Returns the index the workspace actually ended up at. This can differ from `idx`:
+    // the clamp below keeps it out of the hidden block, and clean_up_workspaces() at the
+    // end can remove empty workspaces ahead of it, so the final position is re-resolved
+    // by id rather than trusted from the pre-cleanup insertion point.
+    pub fn insert_workspace(&mut self, mut ws: Workspace<W>, mut idx: usize, activate: bool) -> usize {
         ws.set_output(Some(self.output.clone()));
         ws.update_config(self.options.clone());
+
+        // Hidden workspaces must stay contiguous at the end of the vec: never insert a
+        // visible workspace into or past that block.
+        let first_hidden_idx = self.workspaces.iter().position(|ws| ws.hidden);
+        idx = idx.min(first_hidden_idx.unwrap_or(self.workspaces.len()));
 
         // Don't insert past the last empty workspace.
         if idx == self.workspaces.len() {
@@ -1056,6 +1065,7 @@ impl<W: LayoutElement> Monitor<W> {
             idx += 1;
         }
 
+        let id = ws.id();
         self.workspaces.insert(idx, ws);
 
         if idx <= self.active_workspace_idx {
@@ -1069,6 +1079,11 @@ impl<W: LayoutElement> Monitor<W> {
 
         self.workspace_switch = None;
         self.clean_up_workspaces();
+
+        self.workspaces
+            .iter()
+            .position(|w| w.id() == id)
+            .unwrap_or_else(|| idx.min(self.workspaces.len().saturating_sub(1)))
     }
 
     pub fn append_workspaces(&mut self, mut workspaces: Vec<Workspace<W>>) {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -922,6 +922,13 @@ impl<W: LayoutElement> Monitor<W> {
             return None;
         };
 
+        // Nothing to do if the workspace isn't actually hidden. Avoid the
+        // remove/reinsert work below, which resets workspace_switch and
+        // reorders the workspace vec even though nothing needs to move.
+        if !self.workspaces[idx].hidden {
+            return None;
+        }
+
         // Hidden workspaces are positioned physically after visible workspaces in their
         // workspace vec, because of this on unhide we need to position them to match
         // where they were originally on unhide.

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -898,6 +898,10 @@ impl<W: LayoutElement> Monitor<W> {
         };
         let ws = &mut self.workspaces[idx];
 
+        // Unnaming removes the only way to unhide this workspace later, so it must
+        // not be left pending a hide-on-switch-away (the unhide call above only
+        // clears this when the workspace was actually hidden).
+        ws.needs_hidden = false;
         ws.unname();
 
         if self.workspace_switch.is_none() {
@@ -937,6 +941,10 @@ impl<W: LayoutElement> Monitor<W> {
         ws.hidden = false;
         ws.needs_hidden = needs_hidden;
         ws.original_idx = None;
+        // The vec may have shrunk (other workspaces emptied out and were cleaned up)
+        // while this one stayed hidden, so original_idx can now be stale and past
+        // the end. Clamp it or insert_workspace() panics.
+        let original_idx = original_idx.min(self.workspaces.len());
         self.insert_workspace(ws, original_idx, false);
         return Some(original_idx);
     }


### PR DESCRIPTION
See https://github.com/argosnothing/niri/pull/3