### PR TITLE
Add toggle-window-shader and cycle-window-shader actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ A GLSL fragment shader pipeline layered on top of niri's rendering, in three sco
 
 Supporting machinery:
 
+- Named **`window-shaders` presets** driven by the `toggle-window-shader` and `cycle-window-shader` binds: flip the focused window's shader off/on, or rotate it through your presets at runtime — no config editing or reload needed.
+
 - Two API flavours: a native `niri` mode and a `hyprland` mode that accepts most Hyprland `screen_shader` files with light edits.
 - Multi-pass chains via repeatable `pass {}` blocks, where each pass reads the previous pass's output.
 - A previous-frame feedback buffer (`niri_prev` / `tex2D_prev`) plus a dedicated `global_buffer` pass for trails and accumulation effects.

--- a/docs/wiki/Configuration:-Global-Shader.md
+++ b/docs/wiki/Configuration:-Global-Shader.md
@@ -569,6 +569,30 @@ window-rule {
 }
 ```
 
+#### Window shader presets (`window-shaders`)
+
+A top-level `window-shaders {}` block defines **named shader presets** that can be applied to any window at runtime, without editing window rules:
+
+```kdl
+window-shaders {
+    preset "grayscale" {
+        source "vec4 global_color(vec3 c){ vec3 s=tex2D_screen(c.xy).rgb; float g=dot(s,vec3(0.299,0.587,0.114)); return vec4(vec3(g),1.0); }"
+    }
+    preset "fire" {
+        path "~/.config/niri/shaders/fire.frag"
+    }
+}
+```
+
+Each `preset` takes a name argument followed by the same source fields as a window-rule `shader {}` block (`source`, `path`, `mode`, `pass`). Presets are compiled at config load, and repeated `window-shaders {}` blocks accumulate in order.
+
+Two bindable actions drive them (both also available as `niri msg action ... [--id <window-id>]`):
+
+- `toggle-window-shader` — turns the focused window's shader off and back on. Works on the window-rule shader as well as a selected preset.
+- `cycle-window-shader` — rotates the focused window through: default (the window-rule shader, or none) → first preset → … → last preset → back to default. Cycling always re-enables a shader that was toggled off.
+
+The selection is per-window runtime state: it survives config reloads (presets are re-resolved by name) but is not persisted across compositor restarts. A preset whose name has disappeared from the config falls back to rendering no shader, and the next `cycle-window-shader` restarts at the first preset.
+
 ---
 
 ### Shaders in screencast / screenshots

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -349,6 +349,30 @@ binds {
 }
 ```
 
+#### `toggle-window-shader`
+
+Toggle the focused window's shader on or off.
+This affects the shader applied through a `window-rule { shader {} }` block, or a `window-shaders` preset selected with `cycle-window-shader`.
+See [Per-window shaders](./Configuration:-Global-Shader.md#per-window-shaders).
+
+```kdl
+binds {
+    Mod+S { toggle-window-shader; }
+}
+```
+
+#### `cycle-window-shader`
+
+Cycle the focused window's shader through the presets defined in the top-level `window-shaders {}` block: default (the window-rule shader, or none) → first preset → … → last preset → back to default.
+Cycling re-enables a shader turned off with `toggle-window-shader`.
+See [Window shader presets](./Configuration:-Global-Shader.md#window-shader-presets-window-shaders).
+
+```kdl
+binds {
+    Mod+Shift+S { cycle-window-shader; }
+}
+```
+
 #### `toggle-window-sticky`
 
 <sup>Since: 25.11</sup>

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -339,6 +339,12 @@ pub enum Action {
     ToggleWindowFloating,
     #[knuffel(skip)]
     ToggleWindowFloatingById(u64),
+    ToggleWindowShader,
+    #[knuffel(skip)]
+    ToggleWindowShaderById(u64),
+    CycleWindowShader,
+    #[knuffel(skip)]
+    CycleWindowShaderById(u64),
     ToggleWindowSticky,
     #[knuffel(skip)]
     ToggleWindowStickyById(u64),
@@ -680,6 +686,12 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ToggleWindowFloating { id: Some(id) } => {
                 Self::ToggleWindowFloatingById(id)
             }
+            niri_ipc::Action::ToggleWindowShader { id: None } => Self::ToggleWindowShader,
+            niri_ipc::Action::ToggleWindowShader { id: Some(id) } => {
+                Self::ToggleWindowShaderById(id)
+            }
+            niri_ipc::Action::CycleWindowShader { id: None } => Self::CycleWindowShader,
+            niri_ipc::Action::CycleWindowShader { id: Some(id) } => Self::CycleWindowShaderById(id),
             niri_ipc::Action::ToggleWindowSticky { id: None } => Self::ToggleWindowSticky,
             niri_ipc::Action::ToggleWindowSticky { id: Some(id) } => {
                 Self::ToggleWindowStickyById(id)
@@ -1071,6 +1083,33 @@ impl FromStr for Key {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_window_shader_actions() {
+        let config = crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+S { toggle-window-shader; }
+                Mod+Shift+S { cycle-window-shader; }
+            }
+            "#,
+        )
+        .unwrap();
+        let actions: Vec<_> = config.binds.0.iter().map(|b| b.action.clone()).collect();
+        assert_eq!(
+            actions,
+            [Action::ToggleWindowShader, Action::CycleWindowShader]
+        );
+
+        assert_eq!(
+            Action::from(niri_ipc::Action::ToggleWindowShader { id: Some(5) }),
+            Action::ToggleWindowShaderById(5),
+        );
+        assert_eq!(
+            Action::from(niri_ipc::Action::CycleWindowShader { id: None }),
+            Action::CycleWindowShader,
+        );
+    }
 
     #[test]
     fn parse_xf86_screensaver() {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -44,6 +44,7 @@ pub mod recent_windows;
 pub mod region_shader;
 pub mod utils;
 pub mod window_rule;
+pub mod window_shaders;
 pub mod workspace;
 
 pub use crate::animations::{Animation, Animations};
@@ -67,6 +68,7 @@ pub use crate::window_rule::{
     FloatingPosition, OnXdgActivate, PopupsRule, RelativeTo, ResolvedPopupsRules, ShaderRule,
     WindowRule,
 };
+pub use crate::window_shaders::{WindowShaderPreset, WindowShadersPart};
 pub use crate::workspace::{Workspace, WorkspaceLayoutPart};
 
 const RECURSION_LIMIT: u8 = 10;
@@ -103,6 +105,7 @@ pub struct Config {
     pub workspaces: Vec<Workspace>,
     pub recent_windows: RecentWindows,
     pub region_shaders: Vec<RegionShader>,
+    pub window_shaders: Vec<WindowShaderPreset>,
 }
 
 #[derive(Debug, Clone)]
@@ -181,6 +184,7 @@ where
                     | "layer-rule"
                     | "workspace"
                     | "region-shader"
+                    | "window-shaders"
                     | "include"
             ) && !seen.insert(name)
             {
@@ -234,6 +238,10 @@ where
                 "region-shader" => {
                     let part = RegionShaderPart::decode_node(node, ctx)?;
                     config.borrow_mut().region_shaders.push(part.into());
+                }
+                "window-shaders" => {
+                    let part = WindowShadersPart::decode_node(node, ctx)?;
+                    config.borrow_mut().window_shaders.extend(part.presets);
                 }
 
                 // Single-part sections.
@@ -2495,6 +2503,7 @@ mod tests {
                 ],
             },
             region_shaders: [],
+            window_shaders: [],
         }
         "#);
     }

--- a/niri-config/src/window_shaders.rs
+++ b/niri-config/src/window_shaders.rs
@@ -1,0 +1,103 @@
+//! Named window-shader presets, applied to windows at runtime via the
+//! `toggle-window-shader` / `cycle-window-shader` actions.
+
+use crate::global_shader::GlobalShaderPassPart;
+
+/// One `window-shaders` block; presets from all blocks accumulate in config order.
+#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
+pub struct WindowShadersPart {
+    #[knuffel(children(name = "preset"))]
+    pub presets: Vec<WindowShaderPreset>,
+}
+
+/// A named shader preset with the same source spec as a window-rule `shader {}` block.
+#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
+pub struct WindowShaderPreset {
+    #[knuffel(argument)]
+    pub name: String,
+    #[knuffel(child, unwrap(argument))]
+    pub source: Option<String>,
+    #[knuffel(child, unwrap(argument))]
+    pub path: Option<String>,
+    #[knuffel(child, unwrap(argument))]
+    pub mode: Option<String>,
+    #[knuffel(children(name = "pass"))]
+    pub passes: Vec<GlobalShaderPassPart>,
+}
+
+impl WindowShaderPreset {
+    pub fn pass_sources(&self, expand: impl Fn(&str) -> Option<String>) -> Vec<(String, bool)> {
+        let mode = self.mode.as_deref().unwrap_or("niri");
+        crate::region_shader::resolve_scoped_pass_sources(
+            &self.source,
+            &self.path,
+            mode,
+            &self.passes,
+            expand,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Config;
+
+    #[test]
+    fn window_shaders_presets_parse() {
+        let config = Config::parse_mem(
+            r##"
+            window-shaders {
+                preset "fire" {
+                    source "vec4 global_color(vec3 c){ return tex2D_screen(c.xy).bgra; }"
+                }
+                preset "crt" {
+                    source "vec4 global_color(vec3 c){ return vec4(c.xy, 0.0, 1.0); }"
+                    mode "hyprland"
+                }
+            }
+            "##,
+        )
+        .unwrap();
+
+        assert_eq!(config.window_shaders.len(), 2);
+
+        let fire = &config.window_shaders[0];
+        assert_eq!(fire.name, "fire");
+        let chain = fire.pass_sources(|_| None);
+        assert_eq!(chain.len(), 1);
+        assert!(chain[0].0.contains("bgra"));
+        assert!(!chain[0].1);
+
+        let crt = &config.window_shaders[1];
+        assert_eq!(crt.name, "crt");
+        let chain = crt.pass_sources(|_| None);
+        assert_eq!(chain.len(), 1);
+        assert!(chain[0].1);
+    }
+
+    #[test]
+    fn window_shaders_blocks_accumulate() {
+        let config = Config::parse_mem(
+            r##"
+            window-shaders {
+                preset "a" {
+                    source "vec4 global_color(vec3 c){ return vec4(1.0); }"
+                }
+            }
+            window-shaders {
+                preset "b" {
+                    source "vec4 global_color(vec3 c){ return vec4(0.0); }"
+                }
+            }
+            "##,
+        )
+        .unwrap();
+
+        let names: Vec<_> = config
+            .window_shaders
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(names, ["a", "b"]);
+    }
+}

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -823,6 +823,22 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
     },
+    /// Toggle the window's shader on or off.
+    ToggleWindowShader {
+        /// Id of the window to toggle.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+    },
+    /// Cycle the window's shader through the configured window-shaders presets.
+    CycleWindowShader {
+        /// Id of the window to cycle.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+    },
     /// Toggle whether a window is sticky across all workspaces on the current output.
     ToggleWindowSticky {
         /// Id of the window to toggle.

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -319,6 +319,17 @@ animations {
 //     // reads-cursor     // forces software cursor so the shader can read/transform the cursor
 // }
 
+// Named per-window shader presets for the toggle-window-shader and
+// cycle-window-shader binds (applied to the focused window at runtime).
+// window-shaders {
+//     preset "grayscale" {
+//         source "vec4 global_color(vec3 c) { vec3 s = tex2D_screen(c.xy).rgb; float g = dot(s, vec3(0.299, 0.587, 0.114)); return vec4(vec3(g), 1.0); }"
+//     }
+//     preset "fire" {
+//         path "~/.config/niri/shaders/fire.frag"
+//     }
+// }
+
 // Settings for the overview (Mod+O).
 // overview {
 //     // How much workspaces zoom out in the overview. Ranges from 0 to 0.75.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2350,6 +2350,56 @@ impl State {
                     }
                 }
             }
+            Action::ToggleWindowShader => {
+                let active_window = self
+                    .niri
+                    .layout
+                    .active_workspace_mut()
+                    .and_then(|ws| ws.active_window_mut());
+                if let Some(window) = active_window {
+                    window.toggle_window_shader();
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
+            Action::ToggleWindowShaderById(id) => {
+                let window = self
+                    .niri
+                    .layout
+                    .workspaces_mut()
+                    .find_map(|ws| ws.windows_mut().find(|w| w.id().get() == id));
+                if let Some(window) = window {
+                    window.toggle_window_shader();
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
+            Action::CycleWindowShader => {
+                let config = self.niri.config.clone();
+                let active_window = self
+                    .niri
+                    .layout
+                    .active_workspace_mut()
+                    .and_then(|ws| ws.active_window_mut());
+                if let Some(window) = active_window {
+                    window.cycle_window_shader(&config.borrow());
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
+            Action::CycleWindowShaderById(id) => {
+                let config = self.niri.config.clone();
+                let window = self
+                    .niri
+                    .layout
+                    .workspaces_mut()
+                    .find_map(|ws| ws.windows_mut().find(|w| w.id().get() == id));
+                if let Some(window) = window {
+                    window.cycle_window_shader(&config.borrow());
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
             Action::SetDynamicCastWindow => {
                 let id = self
                     .niri

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -330,6 +330,12 @@ pub trait LayoutElement {
 
     fn rules(&self) -> &ResolvedWindowRules;
 
+    /// The shader that should render for this window right now: the runtime override (from the
+    /// toggle/cycle-window-shader actions) if one is active, the window-rule shader otherwise.
+    fn effective_shader(&self) -> Option<&crate::window::ResolvedShader> {
+        self.rules().shader.as_ref()
+    }
+
     /// Runs periodic clean-up tasks.
     fn refresh(&self);
 

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1221,7 +1221,7 @@ impl<W: LayoutElement> Tile<W> {
         // rule is absent or the program is missing, nothing is pushed and the window
         // renders normally.
         if !pushed_resize {
-            if let Some(resolved) = self.window.rules().shader.clone().filter(|_| {
+            if let Some(resolved) = self.window.effective_shader().cloned().filter(|_| {
                 crate::render_helpers::target_renders_shaders(
                     ctx.target,
                     self.options.shaders_in_capture,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1925,10 +1925,15 @@ impl State {
 
         if config.region_shaders != old_config.region_shaders
             || config.window_rules != old_config.window_rules
+            || config.window_shaders != old_config.window_shaders
         {
             let chains = scoped_shader_chains(&config);
             self.backend.with_primary_renderer(|renderer| {
                 shaders::set_scoped_programs(renderer, &chains);
+            });
+            // Preset selections are stored by name; re-resolve them against the new config.
+            self.niri.layout.with_windows_mut(|mapped, _| {
+                mapped.update_shader_preset(&config);
             });
             shaders_changed = true;
         }
@@ -5913,7 +5918,7 @@ impl Niri {
             // zoomed out (and the per-tile visible flag reflects normal-view culling), so there we
             // fall back to scanning all windows to keep their shaders animating as before.
             let shader_animates = |win: &Mapped| {
-                win.rules().shader.as_ref().map_or(false, |shader| {
+                win.effective_shader().map_or(false, |shader| {
                     niri_config::GlobalShaderCaps::scan_chain(&shader.passes).is_animating()
                 })
             };
@@ -7969,6 +7974,12 @@ pub(crate) fn scoped_shader_chains(config: &niri_config::Config) -> Vec<Vec<(Str
             if !chain.is_empty() {
                 chains.push(chain);
             }
+        }
+    }
+    for preset in &config.window_shaders {
+        let chain = preset.pass_sources(read_scoped_shader_path);
+        if !chain.is_empty() {
+            chains.push(chain);
         }
     }
     chains

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -476,6 +476,8 @@ fn action_name(action: &Action) -> String {
         Action::ConsumeOrExpelWindowLeft => String::from("Consume or Expel Window Left"),
         Action::ConsumeOrExpelWindowRight => String::from("Consume or Expel Window Right"),
         Action::ToggleWindowFloating => String::from("Move Window Between Floating and Tiling"),
+        Action::ToggleWindowShader => String::from("Toggle Window Shader"),
+        Action::CycleWindowShader => String::from("Cycle Window Shader Preset"),
         Action::ToggleWindowSticky => String::from("Toggle Window Sticky Across Workspaces"),
         Action::SwitchFocusBetweenFloatingAndTiling => {
             String::from("Switch Focus Between Floating and Tiling")

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -21,7 +21,9 @@ use smithay::wayland::shell::xdg::{
 };
 use wayland_backend::server::Credentials;
 
-use super::{ResolvedWindowRules, WindowRef};
+use super::{
+    resolve_window_shader_preset, ResolvedShader, ResolvedWindowRules, WindowRef, WindowShaderState,
+};
 use crate::handlers::KdeDecorationsModeState;
 use crate::layout::{
     ConfigureIntent, InteractiveResizeData, LayoutElement, LayoutElementRenderElement,
@@ -104,6 +106,11 @@ pub struct Mapped {
 
     /// Whether this window should ignore opacity set through window rules.
     ignore_opacity_window_rule: bool,
+
+    /// Runtime shader override (toggle/cycle-window-shader actions).
+    shader_state: WindowShaderState,
+    /// Resolved shader for `shader_state.preset`; re-resolved on config reload.
+    shader_preset: Option<ResolvedShader>,
 
     /// Buffer to draw instead of the window when it should be blocked out.
     block_out_buffer: RefCell<SolidColorBuffer>,
@@ -294,6 +301,8 @@ impl Mapped {
             is_sticky: false,
             is_window_cast_target: false,
             ignore_opacity_window_rule: false,
+            shader_state: WindowShaderState::default(),
+            shader_preset: None,
             block_out_buffer: RefCell::new(SolidColorBuffer::new((0., 0.), [0., 0., 0., 1.])),
             blur_config: config.blur,
             animate_next_configure: false,
@@ -392,6 +401,31 @@ impl Mapped {
 
     pub fn toggle_ignore_opacity_window_rule(&mut self) {
         self.ignore_opacity_window_rule = !self.ignore_opacity_window_rule;
+    }
+
+    /// Flip this window's shader on/off, keeping the preset selection.
+    pub fn toggle_window_shader(&mut self) {
+        self.shader_state.toggle();
+    }
+
+    /// Rotate this window's shader through the configured `window-shaders` presets.
+    pub fn cycle_window_shader(&mut self, config: &niri_config::Config) {
+        let names: Vec<String> = config
+            .window_shaders
+            .iter()
+            .map(|p| p.name.clone())
+            .collect();
+        self.shader_state.cycle(&names);
+        self.update_shader_preset(config);
+    }
+
+    /// Re-resolve the selected preset against the current config (call on config reload).
+    pub fn update_shader_preset(&mut self, config: &niri_config::Config) {
+        self.shader_preset = self
+            .shader_state
+            .preset
+            .as_deref()
+            .and_then(|name| resolve_window_shader_preset(name, config));
     }
 
     pub fn set_is_focused(&mut self, is_focused: bool) {
@@ -1376,6 +1410,16 @@ impl LayoutElement for Mapped {
 
     fn rules(&self) -> &ResolvedWindowRules {
         &self.rules
+    }
+
+    fn effective_shader(&self) -> Option<&ResolvedShader> {
+        if self.shader_state.disabled {
+            return None;
+        }
+        if self.shader_state.preset.is_some() {
+            return self.shader_preset.as_ref();
+        }
+        self.rules.shader.as_ref()
     }
 
     fn take_animation_snapshot(&mut self) -> Option<LayoutElementRenderSnapshot> {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -38,6 +38,51 @@ pub struct ResolvedShader {
     pub key: u64,
 }
 
+/// Runtime per-window shader override, driven by the `toggle-window-shader` /
+/// `cycle-window-shader` actions. Lives outside `ResolvedWindowRules` so rule recomputation and
+/// config reload don't clobber the user's choice.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct WindowShaderState {
+    /// Selected `window-shaders` preset name; `None` = the window-rule shader (or nothing).
+    pub preset: Option<String>,
+    /// When true, no shader renders for this window regardless of preset or rule.
+    pub disabled: bool,
+}
+
+impl WindowShaderState {
+    /// Flip the shader on/off, keeping the preset selection.
+    pub fn toggle(&mut self) {
+        self.disabled = !self.disabled;
+    }
+
+    /// Advance to the next stop in default → preset 1 → … → preset N → default, re-enabling the
+    /// shader. A preset name no longer in the config restarts at the first preset.
+    pub fn cycle(&mut self, presets: &[String]) {
+        self.disabled = false;
+        self.preset = match &self.preset {
+            None => presets.first().cloned(),
+            Some(cur) => match presets.iter().position(|p| p == cur) {
+                Some(i) => presets.get(i + 1).cloned(),
+                None => presets.first().cloned(),
+            },
+        };
+    }
+}
+
+/// Resolve a `window-shaders` preset by name into its pass list and cache key.
+pub fn resolve_window_shader_preset(
+    name: &str,
+    config: &niri_config::Config,
+) -> Option<ResolvedShader> {
+    let preset = config.window_shaders.iter().find(|p| p.name == name)?;
+    let passes = preset.pass_sources(crate::niri::read_scoped_shader_path);
+    if passes.is_empty() {
+        return None;
+    }
+    let key = crate::render_helpers::shaders::scoped_key(&passes);
+    Some(ResolvedShader { passes, key })
+}
+
 /// Rules fully resolved for a window.
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct ResolvedWindowRules {
@@ -501,4 +546,101 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
     }
 
     true
+}
+
+#[cfg(test)]
+mod shader_state_tests {
+    use super::*;
+
+    fn presets() -> Vec<String> {
+        vec!["fire".to_owned(), "crt".to_owned()]
+    }
+
+    #[test]
+    fn cycle_rotates_through_presets_and_back_to_default() {
+        let mut state = WindowShaderState::default();
+        state.cycle(&presets());
+        assert_eq!(state.preset.as_deref(), Some("fire"));
+        state.cycle(&presets());
+        assert_eq!(state.preset.as_deref(), Some("crt"));
+        state.cycle(&presets());
+        assert_eq!(state.preset, None);
+        state.cycle(&presets());
+        assert_eq!(state.preset.as_deref(), Some("fire"));
+    }
+
+    #[test]
+    fn cycle_clears_disabled() {
+        let mut state = WindowShaderState {
+            preset: None,
+            disabled: true,
+        };
+        state.cycle(&presets());
+        assert!(!state.disabled);
+        assert_eq!(state.preset.as_deref(), Some("fire"));
+    }
+
+    #[test]
+    fn cycle_with_stale_preset_restarts_at_first() {
+        let mut state = WindowShaderState {
+            preset: Some("gone".to_owned()),
+            disabled: false,
+        };
+        state.cycle(&presets());
+        assert_eq!(state.preset.as_deref(), Some("fire"));
+    }
+
+    #[test]
+    fn cycle_with_no_presets_is_a_noop_but_reenables() {
+        let mut state = WindowShaderState {
+            preset: None,
+            disabled: true,
+        };
+        state.cycle(&[]);
+        assert_eq!(state.preset, None);
+        assert!(!state.disabled);
+    }
+
+    #[test]
+    fn toggle_flips_disabled() {
+        let mut state = WindowShaderState::default();
+        state.toggle();
+        assert!(state.disabled);
+        state.toggle();
+        assert!(!state.disabled);
+    }
+
+    #[test]
+    fn preset_chains_are_compiled() {
+        let config = niri_config::Config::parse_mem(
+            r##"
+            window-shaders {
+                preset "fire" {
+                    source "vec4 global_color(vec3 c){ return tex2D_screen(c.xy).bgra; }"
+                }
+            }
+            "##,
+        )
+        .unwrap();
+        let chains = crate::niri::scoped_shader_chains(&config);
+        assert!(chains.iter().any(|c| c[0].0.contains("bgra")));
+    }
+
+    #[test]
+    fn resolve_preset_by_name() {
+        let config = niri_config::Config::parse_mem(
+            r##"
+            window-shaders {
+                preset "fire" {
+                    source "vec4 global_color(vec3 c){ return tex2D_screen(c.xy).bgra; }"
+                }
+            }
+            "##,
+        )
+        .unwrap();
+        let resolved = resolve_window_shader_preset("fire", &config).unwrap();
+        assert_eq!(resolved.passes.len(), 1);
+        assert!(resolved.passes[0].0.contains("bgra"));
+        assert!(resolve_window_shader_preset("nope", &config).is_none());
+    }
 }


### PR DESCRIPTION
Closes #19.

Adds runtime control over per-window shaders, without editing or reloading window rules:

- **`toggle-window-shader`** — flips the focused window's shader off/on. Works on the shader from a `window-rule { shader {} }` block as well as a selected preset.
- **`cycle-window-shader`** — rotates the focused window through *default (rule shader or none) → preset 1 → … → preset N → default*. Cycling always re-enables a shader that was toggled off.
- Both actions take an optional `--id` via IPC (`niri msg action toggle-window-shader --id <window-id>`), following the `toggle-window-floating` pattern.

Presets come from a new top-level config section, using the same source fields as a window-rule `shader {}` block (`source`/`path`/`mode`/`pass`):

```kdl
window-shaders {
    preset "grayscale" {
        source "vec4 global_color(vec3 c){ vec3 s=tex2D_screen(c.xy).rgb; float g=dot(s,vec3(0.299,0.587,0.114)); return vec4(vec3(g),1.0); }"
    }
    preset "fire" {
        path "~/.config/niri/shaders/fire.frag"
    }
}
```

### Implementation notes

- Preset chains are compiled at config load/reload through the existing `scoped_shader_chains` → `set_scoped_programs` path — no runtime GLSL compilation.
- The selection is runtime state on `Mapped` (preset name + disabled flag), so window-rule recomputation can't clobber it. Config reload re-resolves the preset by name; a preset that disappeared renders no shader and the next cycle restarts at the first preset.
- Render (`tile.rs`) and animating-shader redraw scheduling consult a new `LayoutElement::effective_shader()` instead of reading `rules().shader` directly.
- Docs added to the Global Shader and Key Bindings wiki pages plus a commented `default-config.kdl` block.

### Testing

- Config parse tests for the `window-shaders` section (including multi-block accumulation) and the new bind actions.
- Unit tests for the cycle/toggle state machine, preset resolution, and preset chain compilation.
- Full suite green: niri 270, niri-config 47 + wiki-parses, niri-ipc 2.
- Not yet hardware-tested on sixseven.