### PR TITLE
Fix niri-visual-tests compile errors from fork API drift

### DIFF
--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -72,7 +72,7 @@ impl Layout {
             ..Default::default()
         };
         let mut layout = niri::layout::Layout::with_options(clock.clone(), options);
-        layout.add_output(output.clone(), None);
+        layout.add_output(output.clone(), None, false);
 
         let start_time = clock.now_unadjusted();
 
@@ -278,6 +278,7 @@ impl TestCase for Layout {
             renderer,
             target: RenderTarget::Output,
             xray: None,
+            shader_time: 0.0,
         };
         self.layout
             .monitor_for_output(&self.output)

--- a/niri-visual-tests/src/cases/tile.rs
+++ b/niri-visual-tests/src/cases/tile.rs
@@ -126,6 +126,7 @@ impl TestCase for Tile {
             renderer,
             target: RenderTarget::Output,
             xray: None,
+            shader_time: 0.0,
         };
         let xray_pos = XrayPos::new(location, 1.);
         self.tile

--- a/niri-visual-tests/src/cases/window.rs
+++ b/niri-visual-tests/src/cases/window.rs
@@ -57,6 +57,7 @@ impl TestCase for Window {
             renderer,
             target: RenderTarget::Output,
             xray: None,
+            shader_time: 0.0,
         };
         self.window
             .render_normal(ctx, location, Scale::from(1.), 1., &mut |elem| {


### PR DESCRIPTION
Fixes the `clippy`, `visual tests`, and `fedora` CI jobs: `niri-visual-tests` stopped compiling after two earlier fork API changes, and it went unnoticed because the local devshell has no GTK4 — the crate only builds in CI.

- `Layout::add_output` gained an `isolated: bool` parameter → pass `false`, matching `src/layout/tests.rs`.
- `RenderCtx` gained a `shader_time` field → bind `0.0`; visual tests are static snapshots, same convention as the other snapshot render paths.

> **Note:** this PR was merged while further commits (the hidden-workspace layout fixes for the `randomized and slow tests` job) were still being pushed to its branch; those commits did not land here. They are delivered in #22, which is also where the full write-up lives. This description was trimmed to match what this PR actually merged.
