### PR TITLE
layer-rule: background-effect ignore-opacity (alpha-masked blur)

### DIFF
--- a/docs/wiki/Configuration:-Layer-Rules.md
+++ b/docs/wiki/Configuration:-Layer-Rules.md
@@ -236,6 +236,7 @@ Override the background effect options for this surface.
 
 - `xray`: set to `true` to enable the xray effect, or `false` to disable it.
 - `blur`: set to `true` to enable blur behind this surface, or `false` to force-disable it.
+- `ignore-opacity`: skip the blurred backdrop on transparent parts of the surface. Accepts `true` (equivalent to `0.0`, only fully-transparent pixels skipped), `false` to disable, or a number between `0.0` and `1.0` as the alpha threshold (pixels with alpha `<=` threshold are skipped).
 - `noise`: amount of pixel noise added to the background (helps with color banding from blur).
 - `saturation`: color saturation of the background (`0` is desaturated, `1` is normal, `2` is 200% saturation).
 

--- a/docs/wiki/Configuration:-Layer-Rules.md
+++ b/docs/wiki/Configuration:-Layer-Rules.md
@@ -237,6 +237,7 @@ Override the background effect options for this surface.
 - `xray`: set to `true` to enable the xray effect, or `false` to disable it.
 - `blur`: set to `true` to enable blur behind this surface, or `false` to force-disable it.
 - `ignore-opacity`: skip the blurred backdrop on transparent parts of the surface. Accepts `true` (equivalent to `0.0`, only fully-transparent pixels skipped), `false` to disable, or a number between `0.0` and `1.0` as the alpha threshold (pixels with alpha `<=` threshold are skipped).
+  This is a compositor-side workaround for clients that do not declare a blur region through the [ext-background-effect protocol](https://wayland.app/protocols/ext-background-effect-v1); it does not reduce the cost of the blur itself. The mask samples the layer's own buffer, so surfaces using subsurfaces or viewport cropping may not mask precisely.
 - `noise`: amount of pixel noise added to the background (helps with color banding from blur).
 - `saturation`: color saturation of the background (`0` is desaturated, `1` is normal, `2` is 200% saturation).
 

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -1013,6 +1013,7 @@ Override the background effect options for this window.
 
 - `xray`: set to `true` to enable the xray effect, or `false` to disable it.
 - `blur`: set to `true` to enable blur behind this window, or `false` to force-disable it.
+- `ignore-opacity`: skip the blurred backdrop on transparent parts of the window surface. Accepts `true` (equivalent to `0.0`, only fully-transparent pixels skipped), `false` to disable, or a number between `0.0` and `1.0` as the alpha threshold (pixels with alpha `<=` threshold are skipped). Mostly useful for floating windows whose buffers include transparent margins, e.g. client-side drop shadows.
 - `noise`: amount of pixel noise added to the background (helps with color banding from blur).
 - `saturation`: color saturation of the background (`0` is desaturated, `1` is normal, `2` is 200% saturation).
 

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -1062,6 +1062,8 @@ pub struct BackgroundEffectRule {
     #[knuffel(child, unwrap(argument))]
     pub blur: Option<bool>,
     #[knuffel(child, unwrap(argument))]
+    pub ignore_opacity: Option<crate::utils::BoolOrFloat>,
+    #[knuffel(child, unwrap(argument))]
     pub noise: Option<FloatOrInt<0, 1000>>,
     #[knuffel(child, unwrap(argument))]
     pub saturation: Option<FloatOrInt<0, 1000>>,
@@ -1085,6 +1087,11 @@ pub struct BackgroundEffect {
     /// - `Some(true)`: always blur
     pub blur: Option<bool>,
 
+    /// Alpha threshold for blur. When set, pixels of the surface with alpha `<=` this value
+    /// do not get a blurred backdrop. `None` disables alpha-masking. `Some(0.0)` matches the
+    /// historical `ignore-opacity true` behavior (only fully-transparent pixels excluded).
+    pub ignore_opacity: Option<f64>,
+
     pub noise: Option<f64>,
     pub saturation: Option<f64>,
 }
@@ -1092,6 +1099,10 @@ pub struct BackgroundEffect {
 impl MergeWith<BackgroundEffectRule> for BackgroundEffect {
     fn merge_with(&mut self, part: &BackgroundEffectRule) {
         merge_clone_opt!((self, part), xray, blur);
+
+        if let Some(x) = part.ignore_opacity {
+            self.ignore_opacity = x.threshold();
+        }
 
         if let Some(x) = part.noise {
             self.noise = Some(x.0);

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -57,7 +57,7 @@ pub use crate::misc::*;
 pub use crate::output::{Output, OutputName, Outputs, Position, Vrr};
 use crate::recent_windows::RecentWindowsPart;
 pub use crate::recent_windows::{MruDirection, MruFilter, MruPreviews, MruScope, RecentWindows};
-pub use crate::utils::FloatOrInt;
+pub use crate::utils::{BoolOrFloat, FloatOrInt};
 use crate::utils::{Flag, MergeWith as _};
 pub use crate::window_rule::{
     FloatingPosition, PopupsRule, RelativeTo, ResolvedPopupsRules, WindowRule,
@@ -1877,6 +1877,7 @@ mod tests {
                     background_effect: BackgroundEffectRule {
                         xray: None,
                         blur: None,
+                        ignore_opacity: None,
                         noise: None,
                         saturation: None,
                     },
@@ -1886,6 +1887,7 @@ mod tests {
                         background_effect: BackgroundEffectRule {
                             xray: None,
                             blur: None,
+                            ignore_opacity: None,
                             noise: None,
                             saturation: None,
                         },
@@ -1928,6 +1930,7 @@ mod tests {
                     background_effect: BackgroundEffectRule {
                         xray: None,
                         blur: None,
+                        ignore_opacity: None,
                         noise: None,
                         saturation: None,
                     },
@@ -1937,6 +1940,7 @@ mod tests {
                         background_effect: BackgroundEffectRule {
                             xray: None,
                             blur: None,
+                            ignore_opacity: None,
                             noise: None,
                             saturation: None,
                         },

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -694,6 +694,62 @@ mod tests {
     }
 
     #[test]
+    fn parse_background_effect_ignore_opacity() {
+        let parsed = do_parse(
+            r#"
+            layer-rule { background-effect { ignore-opacity true; }; }
+            layer-rule { background-effect { ignore-opacity false; }; }
+            layer-rule { background-effect { ignore-opacity 0.7; }; }
+            layer-rule { background-effect { ignore-opacity 1; }; }
+            layer-rule { background-effect { blur true; }; }
+            window-rule { background-effect { ignore-opacity 0.25; }; }
+            "#,
+        );
+
+        let values: Vec<_> = parsed
+            .layer_rules
+            .iter()
+            .map(|rule| rule.background_effect.ignore_opacity)
+            .collect();
+        assert_eq!(
+            values,
+            vec![
+                Some(BoolOrFloat::True),
+                Some(BoolOrFloat::False),
+                Some(BoolOrFloat::Threshold(0.7)),
+                Some(BoolOrFloat::Threshold(1.0)),
+                None,
+            ]
+        );
+        assert_eq!(
+            parsed.window_rules[0].background_effect.ignore_opacity,
+            Some(BoolOrFloat::Threshold(0.25))
+        );
+
+        // Resolved thresholds: `true` means only fully transparent pixels are skipped,
+        // `false` disables masking.
+        let mut effect = BackgroundEffect::default();
+        effect.merge_with(&parsed.layer_rules[0].background_effect);
+        assert_eq!(effect.ignore_opacity, Some(0.0));
+        effect.merge_with(&parsed.layer_rules[2].background_effect);
+        assert_eq!(effect.ignore_opacity, Some(0.7));
+        effect.merge_with(&parsed.layer_rules[1].background_effect);
+        assert_eq!(effect.ignore_opacity, None);
+        // A rule that does not mention the option leaves the merged value alone.
+        effect.merge_with(&parsed.layer_rules[3].background_effect);
+        effect.merge_with(&parsed.layer_rules[4].background_effect);
+        assert_eq!(effect.ignore_opacity, Some(1.0));
+
+        for bad in ["1.5", "-0.1", "2", "\"yes\"", "null"] {
+            let text = format!("layer-rule {{ background-effect {{ ignore-opacity {bad}; }}; }}");
+            assert!(
+                Config::parse_mem(&text).is_err(),
+                "ignore-opacity {bad} should fail to parse"
+            );
+        }
+    }
+
+    #[test]
     fn parse_on_xdg_activate() {
         let parsed = do_parse(
             r#"

--- a/niri-config/src/utils.rs
+++ b/niri-config/src/utils.rs
@@ -23,6 +23,23 @@ pub struct FloatOrInt<const MIN: i32, const MAX: i32>(pub f64);
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Flag(#[knuffel(argument, default = true)] pub bool);
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BoolOrFloat {
+    True,
+    False,
+    Threshold(f64),
+}
+
+impl BoolOrFloat {
+    pub fn threshold(self) -> Option<f64> {
+        match self {
+            Self::True => Some(0.0),
+            Self::False => None,
+            Self::Threshold(t) => Some(t),
+        }
+    }
+}
+
 /// `Regex` that implements `PartialEq` by its string form.
 #[derive(Debug, Clone)]
 pub struct RegexEq(pub Regex);
@@ -69,6 +86,74 @@ impl<const MIN: i32, const MAX: i32> MergeWith<FloatOrInt<MIN, MAX>> for f64 {
 impl MergeWith<Flag> for bool {
     fn merge_with(&mut self, part: &Flag) {
         *self = part.0;
+    }
+}
+
+impl<S: knuffel::traits::ErrorSpan> knuffel::DecodeScalar<S> for BoolOrFloat {
+    fn type_check(
+        type_name: &Option<knuffel::span::Spanned<knuffel::ast::TypeName, S>>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) {
+        if let Some(type_name) = &type_name {
+            ctx.emit_error(DecodeError::unexpected(
+                type_name,
+                "type name",
+                "no type name expected for this node",
+            ));
+        }
+    }
+
+    fn raw_decode(
+        val: &knuffel::span::Spanned<knuffel::ast::Literal, S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        match &**val {
+            knuffel::ast::Literal::Bool(b) => {
+                Ok(if *b { BoolOrFloat::True } else { BoolOrFloat::False })
+            }
+            knuffel::ast::Literal::Decimal(ref value) => match value.try_into() {
+                Ok(v) => {
+                    if (0.0..=1.0).contains(&v) {
+                        Ok(BoolOrFloat::Threshold(v))
+                    } else {
+                        ctx.emit_error(DecodeError::conversion(
+                            val,
+                            "threshold must be between 0.0 and 1.0",
+                        ));
+                        Ok(BoolOrFloat::False)
+                    }
+                }
+                Err(e) => {
+                    ctx.emit_error(DecodeError::conversion(val, e));
+                    Ok(BoolOrFloat::False)
+                }
+            },
+            knuffel::ast::Literal::Int(ref value) => match value.try_into() {
+                Ok(v) => {
+                    let v: i64 = v;
+                    if (0..=1).contains(&v) {
+                        Ok(BoolOrFloat::Threshold(v as f64))
+                    } else {
+                        ctx.emit_error(DecodeError::conversion(
+                            val,
+                            "threshold must be between 0.0 and 1.0",
+                        ));
+                        Ok(BoolOrFloat::False)
+                    }
+                }
+                Err(e) => {
+                    ctx.emit_error(DecodeError::conversion(val, e));
+                    Ok(BoolOrFloat::False)
+                }
+            },
+            _ => {
+                ctx.emit_error(DecodeError::unsupported(
+                    val,
+                    "expected a bool or a number between 0.0 and 1.0",
+                ));
+                Ok(BoolOrFloat::False)
+            }
+        }
     }
 }
 

--- a/niri-config/src/utils.rs
+++ b/niri-config/src/utils.rs
@@ -108,9 +108,11 @@ impl<S: knuffel::traits::ErrorSpan> knuffel::DecodeScalar<S> for BoolOrFloat {
         ctx: &mut knuffel::decode::Context<S>,
     ) -> Result<Self, DecodeError<S>> {
         match &**val {
-            knuffel::ast::Literal::Bool(b) => {
-                Ok(if *b { BoolOrFloat::True } else { BoolOrFloat::False })
-            }
+            knuffel::ast::Literal::Bool(b) => Ok(if *b {
+                BoolOrFloat::True
+            } else {
+                BoolOrFloat::False
+            }),
             knuffel::ast::Literal::Decimal(ref value) => match value.try_into() {
                 Ok(v) => {
                     if (0.0..=1.0).contains(&v) {

--- a/src/render_helpers/aux_texture.rs
+++ b/src/render_helpers/aux_texture.rs
@@ -1,0 +1,35 @@
+//! Binding extra sampler textures next to the primary texture of a GLES draw.
+//!
+//! Smithay's texture draws bind their texture on unit 0. Shaders that read additional textures
+//! (alpha masks, feedback buffers, captured screen regions) bind them on the units after it and
+//! point their sampler uniforms at those units.
+
+use smithay::backend::renderer::gles::ffi;
+use smithay::backend::renderer::gles::ffi::types::{GLenum, GLuint};
+
+/// Binds `tex_id` as a 2D texture on texture unit `unit` with linear filtering and the given
+/// wrap mode, then makes unit 0 active again.
+///
+/// # Safety
+///
+/// Must be called with a current GL context, from inside a renderer `with_context` callback.
+pub unsafe fn bind(gl: &ffi::Gles2, unit: u32, tex_id: GLuint, wrap: GLenum) {
+    gl.ActiveTexture(ffi::TEXTURE0 + unit);
+    gl.BindTexture(ffi::TEXTURE_2D, tex_id);
+    gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
+    gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
+    gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_WRAP_S, wrap as i32);
+    gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_WRAP_T, wrap as i32);
+    gl.ActiveTexture(ffi::TEXTURE0);
+}
+
+/// Unbinds the 2D texture on unit `unit`, then makes unit 0 active again.
+///
+/// # Safety
+///
+/// Same requirements as [`bind`].
+pub unsafe fn unbind(gl: &ffi::Gles2, unit: u32) {
+    gl.ActiveTexture(ffi::TEXTURE0 + unit);
+    gl.BindTexture(ffi::TEXTURE_2D, 0);
+    gl.ActiveTexture(ffi::TEXTURE0);
+}

--- a/src/render_helpers/background_effect.rs
+++ b/src/render_helpers/background_effect.rs
@@ -1,7 +1,9 @@
 use std::sync::{Arc, Mutex};
 
 use niri_config::CornerRadius;
-use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
+use smithay::backend::renderer::utils::{import_surface, RendererSurfaceStateUserData};
+use smithay::backend::renderer::Renderer as _;
 use smithay::utils::{Logical, Point, Rectangle, Scale};
 use smithay::wayland::compositor::{with_states, SurfaceData};
 use wayland_server::protocol::wl_surface::WlSurface;
@@ -34,6 +36,7 @@ pub struct BackgroundEffect {
 pub struct Options {
     pub blur: bool,
     pub xray: bool,
+    pub ignore_opacity: Option<f64>,
     pub noise: Option<f64>,
     pub saturation: Option<f64>,
 }
@@ -124,6 +127,7 @@ impl BackgroundEffect {
         let mut options = Options {
             blur,
             xray: effect.xray == Some(true),
+            ignore_opacity: effect.ignore_opacity,
             noise: effect.noise,
             saturation: effect.saturation,
         };
@@ -154,6 +158,7 @@ impl BackgroundEffect {
         ns: Option<usize>,
         mut params: RenderParams,
         xray_pos: XrayPos,
+        alpha_mask: Option<AlphaMask>,
         push: &mut dyn FnMut(BackgroundEffectElement),
     ) {
         if !self.is_visible() {
@@ -180,6 +185,14 @@ impl BackgroundEffect {
         };
         let saturation = self.options.saturation.unwrap_or(saturation) as f32;
 
+        let alpha_mask = match (self.options.ignore_opacity, alpha_mask) {
+            (Some(threshold), Some(mut m)) => {
+                m.threshold = threshold as f32;
+                Some(m)
+            }
+            _ => None,
+        };
+
         if self.options.xray {
             let Some(xray) = ctx.xray else {
                 return;
@@ -193,16 +206,24 @@ impl BackgroundEffect {
                 blur,
                 noise,
                 saturation,
+                alpha_mask,
                 &mut |elem| push(elem.into()),
             );
         } else {
             // Render non-xray effect.
-            let elem = self
-                .nonxray
-                .render(ns, params, blur_options, noise, saturation);
+            let elem =
+                self.nonxray
+                    .render(ns, params, blur_options, noise, saturation, alpha_mask);
             push(elem.into());
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct AlphaMask {
+    pub surface_tex: GlesTexture,
+    pub surface_geo: Rectangle<f64, Logical>,
+    pub threshold: f32,
 }
 
 fn render_params_for_tile(
@@ -311,8 +332,32 @@ pub fn render_for_tile(
             return;
         }
 
-        let mut surface_geo = surface_geo(states).unwrap_or_default().to_f64();
-        surface_geo.loc += surface_off;
+        let mut surface_geo_logical = surface_geo(states).unwrap_or_default().to_f64();
+        surface_geo_logical.loc += surface_off;
+
+        let alpha_mask = if background_effect.options.ignore_opacity.is_some()
+            && !should_block_out
+        {
+            let _ = import_surface(ctx.renderer, states);
+            let data = states.data_map.get::<RendererSurfaceStateUserData>();
+            let texture = data.and_then(|data| {
+                data.lock()
+                    .unwrap()
+                    .texture(ctx.renderer.context_id())
+                    .cloned()
+            });
+
+            let mut mask_geo = surface_geo_logical.upscale(surface_anim_scale);
+            mask_geo.loc += geometry.loc;
+
+            texture.map(|surface_tex| AlphaMask {
+                surface_tex,
+                surface_geo: mask_geo,
+                threshold: 0.0,
+            })
+        } else {
+            None
+        };
 
         let Some(params) = render_params_for_tile(
             geometry,
@@ -320,13 +365,13 @@ pub fn render_for_tile(
             clip_to_geometry,
             should_block_out,
             blur_region,
-            surface_geo,
+            surface_geo_logical,
             surface_anim_scale,
         ) else {
             return;
         };
 
         let xray_pos = xray_pos.offset(params.geometry.loc - geometry.loc);
-        background_effect.render(ctx, ns, params, xray_pos, push);
+        background_effect.render(ctx, ns, params, xray_pos, alpha_mask, push);
     });
 }

--- a/src/render_helpers/background_effect.rs
+++ b/src/render_helpers/background_effect.rs
@@ -211,9 +211,9 @@ impl BackgroundEffect {
             );
         } else {
             // Render non-xray effect.
-            let elem =
-                self.nonxray
-                    .render(ns, params, blur_options, noise, saturation, alpha_mask);
+            let elem = self
+                .nonxray
+                .render(ns, params, blur_options, noise, saturation, alpha_mask);
             push(elem.into());
         }
     }
@@ -335,8 +335,7 @@ pub fn render_for_tile(
         let mut surface_geo_logical = surface_geo(states).unwrap_or_default().to_f64();
         surface_geo_logical.loc += surface_off;
 
-        let alpha_mask = if background_effect.options.ignore_opacity.is_some()
-            && !should_block_out
+        let alpha_mask = if background_effect.options.ignore_opacity.is_some() && !should_block_out
         {
             let _ = import_surface(ctx.renderer, states);
             let data = states.data_map.get::<RendererSurfaceStateUserData>();

--- a/src/render_helpers/background_effect.rs
+++ b/src/render_helpers/background_effect.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Mutex};
 
+use glam::{Mat3, Vec2};
 use niri_config::CornerRadius;
 use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
 use smithay::backend::renderer::utils::{import_surface, RendererSurfaceStateUserData};
@@ -219,11 +220,26 @@ impl BackgroundEffect {
     }
 }
 
+/// Texture unit the alpha-mask surface texture is bound to (`surface_tex` sampler).
+pub const ALPHA_MASK_UNIT: u32 = 1;
+
 #[derive(Debug, Clone)]
 pub struct AlphaMask {
     pub surface_tex: GlesTexture,
     pub surface_geo: Rectangle<f64, Logical>,
     pub threshold: f32,
+}
+
+impl AlphaMask {
+    /// Matrix mapping normalized surface-geometry coordinates (0..1 across `surface_geo`, y
+    /// down) to texture UVs, accounting for y-inverted (EGL/dmabuf) surface textures.
+    pub fn geo_to_uv(&self) -> Mat3 {
+        if self.surface_tex.is_y_inverted() {
+            Mat3::from_translation(Vec2::new(0., 1.)) * Mat3::from_scale(Vec2::new(1., -1.))
+        } else {
+            Mat3::IDENTITY
+        }
+    }
 }
 
 fn render_params_for_tile(

--- a/src/render_helpers/framebuffer_effect.rs
+++ b/src/render_helpers/framebuffer_effect.rs
@@ -14,7 +14,7 @@ use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Transform};
 
 use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
-use crate::render_helpers::background_effect::RenderParams;
+use crate::render_helpers::background_effect::{AlphaMask, RenderParams};
 use crate::render_helpers::blur::{Blur, BlurOptions};
 use crate::render_helpers::renderer::AsGlesFrame as _;
 use crate::render_helpers::shaders::{mat3_uniform, Shaders};
@@ -38,6 +38,7 @@ pub struct FramebufferEffectElement {
     blur_options: Option<BlurOptions>,
     noise: f32,
     saturation: f32,
+    alpha_mask: Option<AlphaMask>,
 }
 
 #[derive(Debug)]
@@ -68,6 +69,7 @@ impl FramebufferEffect {
         blur_options: Option<BlurOptions>,
         noise: f32,
         saturation: f32,
+        alpha_mask: Option<AlphaMask>,
     ) -> FramebufferEffectElement {
         let (clip_geo, corner_radius) = params
             .clip
@@ -89,6 +91,7 @@ impl FramebufferEffect {
             blur_options,
             noise,
             saturation,
+            alpha_mask,
         }
     }
 }
@@ -98,7 +101,7 @@ impl FramebufferEffectElement {
         &self,
         crop: Rectangle<f64, Logical>,
         transform: Transform,
-    ) -> [Uniform<'static>; 7] {
+    ) -> [Uniform<'static>; 11] {
         let offset = crop.loc - (self.clip_geo.loc - self.geometry.loc);
         let offset = Vec2::new(offset.x as f32, offset.y as f32);
         let crop_size = Vec2::new(crop.size.w as f32, crop.size.h as f32);
@@ -116,6 +119,22 @@ impl FramebufferEffectElement {
 
         let clip_geo_size = (self.clip_geo.size.w as f32, self.clip_geo.size.h as f32);
 
+        let (surface_to_geo, alpha_mask_enabled, alpha_threshold) = match &self.alpha_mask {
+            Some(mask) if mask.surface_geo.size.w > 0. && mask.surface_geo.size.h > 0. => {
+                let surface_offset = crop.loc - (mask.surface_geo.loc - self.geometry.loc);
+                let surface_offset =
+                    Vec2::new(surface_offset.x as f32, surface_offset.y as f32);
+                let surface_size = Vec2::new(
+                    mask.surface_geo.size.w as f32,
+                    mask.surface_geo.size.h as f32,
+                );
+                let s2g = Mat3::from_scale(crop_size / surface_size)
+                    * Mat3::from_translation(surface_offset / crop_size);
+                (s2g * transform_mat, 1i32, mask.threshold)
+            }
+            _ => (Mat3::IDENTITY, 0i32, 0.0),
+        };
+
         [
             Uniform::new("niri_scale", self.scale),
             Uniform::new("geo_size", clip_geo_size),
@@ -124,6 +143,10 @@ impl FramebufferEffectElement {
             Uniform::new("noise", self.noise),
             Uniform::new("saturation", self.saturation),
             Uniform::new("bg_color", [0f32, 0., 0., 0.]),
+            mat3_uniform("surface_to_geo", surface_to_geo),
+            Uniform::new("alpha_mask_enabled", alpha_mask_enabled),
+            Uniform::new("alpha_threshold", alpha_threshold),
+            Uniform::new("surface_tex", 1i32),
         ]
     }
 }
@@ -394,7 +417,40 @@ impl RenderElement<GlesRenderer> for FramebufferEffectElement {
             .then(|| self.compute_uniforms(crop, frame.transformation()));
         let uniforms = uniforms.as_ref().map_or(&[][..], |x| &x[..]);
 
-        frame.render_texture_from_to(
+        let surface_tex_id = self
+            .alpha_mask
+            .as_ref()
+            .filter(|_| program.is_some())
+            .map(|mask| mask.surface_tex.tex_id());
+        if let Some(tex_id) = surface_tex_id {
+            frame.with_context(|gl| unsafe {
+                gl.ActiveTexture(ffi::TEXTURE1);
+                gl.BindTexture(ffi::TEXTURE_2D, tex_id);
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_MIN_FILTER,
+                    ffi::LINEAR as i32,
+                );
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_MAG_FILTER,
+                    ffi::LINEAR as i32,
+                );
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_WRAP_S,
+                    ffi::CLAMP_TO_EDGE as i32,
+                );
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_WRAP_T,
+                    ffi::CLAMP_TO_EDGE as i32,
+                );
+                gl.ActiveTexture(ffi::TEXTURE0);
+            })?;
+        }
+
+        let result = frame.render_texture_from_to(
             texture,
             Rectangle::from_size(texture.size().to_f64()),
             clamped_dst,
@@ -405,7 +461,17 @@ impl RenderElement<GlesRenderer> for FramebufferEffectElement {
             1.,
             program.as_ref(),
             uniforms,
-        )
+        );
+
+        if surface_tex_id.is_some() {
+            frame.with_context(|gl| unsafe {
+                gl.ActiveTexture(ffi::TEXTURE1);
+                gl.BindTexture(ffi::TEXTURE_2D, 0);
+                gl.ActiveTexture(ffi::TEXTURE0);
+            })?;
+        }
+
+        result
     }
 }
 

--- a/src/render_helpers/framebuffer_effect.rs
+++ b/src/render_helpers/framebuffer_effect.rs
@@ -122,8 +122,7 @@ impl FramebufferEffectElement {
         let (surface_to_geo, alpha_mask_enabled, alpha_threshold) = match &self.alpha_mask {
             Some(mask) if mask.surface_geo.size.w > 0. && mask.surface_geo.size.h > 0. => {
                 let surface_offset = crop.loc - (mask.surface_geo.loc - self.geometry.loc);
-                let surface_offset =
-                    Vec2::new(surface_offset.x as f32, surface_offset.y as f32);
+                let surface_offset = Vec2::new(surface_offset.x as f32, surface_offset.y as f32);
                 let surface_size = Vec2::new(
                     mask.surface_geo.size.w as f32,
                     mask.surface_geo.size.h as f32,
@@ -426,16 +425,8 @@ impl RenderElement<GlesRenderer> for FramebufferEffectElement {
             frame.with_context(|gl| unsafe {
                 gl.ActiveTexture(ffi::TEXTURE1);
                 gl.BindTexture(ffi::TEXTURE_2D, tex_id);
-                gl.TexParameteri(
-                    ffi::TEXTURE_2D,
-                    ffi::TEXTURE_MIN_FILTER,
-                    ffi::LINEAR as i32,
-                );
-                gl.TexParameteri(
-                    ffi::TEXTURE_2D,
-                    ffi::TEXTURE_MAG_FILTER,
-                    ffi::LINEAR as i32,
-                );
+                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
+                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
                 gl.TexParameteri(
                     ffi::TEXTURE_2D,
                     ffi::TEXTURE_WRAP_S,

--- a/src/render_helpers/framebuffer_effect.rs
+++ b/src/render_helpers/framebuffer_effect.rs
@@ -14,11 +14,11 @@ use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Transform};
 
 use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
-use crate::render_helpers::background_effect::{AlphaMask, RenderParams};
+use crate::render_helpers::background_effect::{AlphaMask, RenderParams, ALPHA_MASK_UNIT};
 use crate::render_helpers::blur::{Blur, BlurOptions};
-use crate::render_helpers::capture;
 use crate::render_helpers::renderer::AsGlesFrame as _;
 use crate::render_helpers::shaders::{mat3_uniform, Shaders};
+use crate::render_helpers::{aux_texture, capture};
 use crate::utils::region::TransformedRegion;
 
 #[derive(Debug)]
@@ -130,7 +130,7 @@ impl FramebufferEffectElement {
                 );
                 let s2g = Mat3::from_scale(crop_size / surface_size)
                     * Mat3::from_translation(surface_offset / crop_size);
-                (s2g * transform_mat, 1i32, mask.threshold)
+                (mask.geo_to_uv() * s2g * transform_mat, 1i32, mask.threshold)
             }
             _ => (Mat3::IDENTITY, 0i32, 0.0),
         };
@@ -146,7 +146,7 @@ impl FramebufferEffectElement {
             mat3_uniform("surface_to_geo", surface_to_geo),
             Uniform::new("alpha_mask_enabled", alpha_mask_enabled),
             Uniform::new("alpha_threshold", alpha_threshold),
-            Uniform::new("surface_tex", 1i32),
+            Uniform::new("surface_tex", ALPHA_MASK_UNIT as i32),
         ]
     }
 }
@@ -380,21 +380,7 @@ impl RenderElement<GlesRenderer> for FramebufferEffectElement {
             .map(|mask| mask.surface_tex.tex_id());
         if let Some(tex_id) = surface_tex_id {
             frame.with_context(|gl| unsafe {
-                gl.ActiveTexture(ffi::TEXTURE1);
-                gl.BindTexture(ffi::TEXTURE_2D, tex_id);
-                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
-                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
-                gl.TexParameteri(
-                    ffi::TEXTURE_2D,
-                    ffi::TEXTURE_WRAP_S,
-                    ffi::CLAMP_TO_EDGE as i32,
-                );
-                gl.TexParameteri(
-                    ffi::TEXTURE_2D,
-                    ffi::TEXTURE_WRAP_T,
-                    ffi::CLAMP_TO_EDGE as i32,
-                );
-                gl.ActiveTexture(ffi::TEXTURE0);
+                aux_texture::bind(gl, ALPHA_MASK_UNIT, tex_id, ffi::CLAMP_TO_EDGE);
             })?;
         }
 
@@ -412,11 +398,7 @@ impl RenderElement<GlesRenderer> for FramebufferEffectElement {
         );
 
         if surface_tex_id.is_some() {
-            frame.with_context(|gl| unsafe {
-                gl.ActiveTexture(ffi::TEXTURE1);
-                gl.BindTexture(ffi::TEXTURE_2D, 0);
-                gl.ActiveTexture(ffi::TEXTURE0);
-            })?;
+            frame.with_context(|gl| unsafe { aux_texture::unbind(gl, ALPHA_MASK_UNIT) })?;
         }
 
         result

--- a/src/render_helpers/framebuffer_effect.rs
+++ b/src/render_helpers/framebuffer_effect.rs
@@ -4,7 +4,9 @@ use glam::{Mat3, Vec2};
 use niri_config::CornerRadius;
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::element::{Element, Id, RenderElement};
-use smithay::backend::renderer::gles::{GlesError, GlesFrame, GlesRenderer, GlesTexture, Uniform};
+use smithay::backend::renderer::gles::{
+    ffi, GlesError, GlesFrame, GlesRenderer, GlesTexture, Uniform,
+};
 use smithay::backend::renderer::utils::CommitCounter;
 use smithay::backend::renderer::{Frame as _, FrameContext, Offscreen, Texture as _};
 use smithay::gpu_span_location;

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -26,6 +26,7 @@ use self::texture::{TextureBuffer, TextureRenderElement};
 use crate::render_helpers::renderer::AsGlesRenderer;
 use crate::render_helpers::xray::Xray;
 
+pub mod aux_texture;
 pub mod background_effect;
 pub mod blur;
 pub mod border;

--- a/src/render_helpers/shader_element.rs
+++ b/src/render_helpers/shader_element.rs
@@ -17,6 +17,7 @@ use super::renderer::AsGlesFrame;
 use super::resources::Resources;
 use super::shaders::{ProgramType, Shaders};
 use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
+use crate::render_helpers::aux_texture;
 
 /// Renders a shader with optional texture input, on the primary GPU.
 #[derive(Debug, Clone)]
@@ -387,20 +388,7 @@ impl RenderElement<GlesRenderer> for ShaderRenderElement {
 
             unsafe {
                 for (i, texture) in self.textures.values().enumerate() {
-                    gl.ActiveTexture(ffi::TEXTURE0 + i as u32);
-                    gl.BindTexture(ffi::TEXTURE_2D, texture.tex_id());
-                    gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
-                    gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
-                    gl.TexParameteri(
-                        ffi::TEXTURE_2D,
-                        ffi::TEXTURE_WRAP_S,
-                        ffi::CLAMP_TO_BORDER as i32,
-                    );
-                    gl.TexParameteri(
-                        ffi::TEXTURE_2D,
-                        ffi::TEXTURE_WRAP_T,
-                        ffi::CLAMP_TO_BORDER as i32,
-                    );
+                    aux_texture::bind(gl, i as u32, texture.tex_id(), ffi::CLAMP_TO_BORDER);
                 }
 
                 gl.UseProgram(program.program);
@@ -501,9 +489,9 @@ impl RenderElement<GlesRenderer> for ShaderRenderElement {
                 }
 
                 gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
-                gl.BindTexture(ffi::TEXTURE_2D, 0);
-                gl.ActiveTexture(ffi::TEXTURE0);
-                gl.BindTexture(ffi::TEXTURE_2D, 0);
+                for i in 0..self.textures.len() {
+                    aux_texture::unbind(gl, i as u32);
+                }
                 gl.DisableVertexAttribArray(program.attrib_vert as u32);
                 gl.DisableVertexAttribArray(program.attrib_vert_position as u32);
             }

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -119,6 +119,10 @@ impl Shaders {
                     UniformName::new("noise", UniformType::_1f),
                     UniformName::new("saturation", UniformType::_1f),
                     UniformName::new("bg_color", UniformType::_4f),
+                    UniformName::new("surface_to_geo", UniformType::Matrix3x3),
+                    UniformName::new("alpha_mask_enabled", UniformType::_1i),
+                    UniformName::new("alpha_threshold", UniformType::_1f),
+                    UniformName::new("surface_tex", UniformType::_1i),
                 ],
             )
             .map_err(|err| {

--- a/src/render_helpers/shaders/postprocess.frag
+++ b/src/render_helpers/shaders/postprocess.frag
@@ -2,6 +2,11 @@ uniform float noise;
 uniform float saturation;
 uniform vec4 bg_color;
 
+uniform sampler2D surface_tex;
+uniform int alpha_mask_enabled;
+uniform float alpha_threshold;
+uniform mat3 surface_to_geo;
+
 // Sin-less white noise by David Hoskins (MIT License).
 // https://www.shadertoy.com/view/4djSRW
 float hash12(vec2 p) {
@@ -16,6 +21,20 @@ vec3 saturate(vec3 color, float sat) {
 }
 
 vec4 postprocess(vec4 color) {
+    // Alpha-mask the blurred backdrop by the layer surface's own alpha. Fragments where the
+    // surface is fully transparent get zeroed so the unblurred backdrop shows through.
+    if (alpha_mask_enabled == 1) {
+        vec3 surface_coords = surface_to_geo * vec3(v_coords, 1.0);
+        if (surface_coords.x < 0.0 || surface_coords.x > 1.0
+            || surface_coords.y < 0.0 || surface_coords.y > 1.0) {
+            return vec4(0.0);
+        }
+        float surface_a = texture2D(surface_tex, surface_coords.xy).a;
+        if (surface_a <= alpha_threshold) {
+            return vec4(0.0);
+        }
+    }
+
     if (saturation != 1.0) {
         color.rgb = saturate(color.rgb, saturation);
     }

--- a/src/render_helpers/xray.rs
+++ b/src/render_helpers/xray.rs
@@ -136,12 +136,11 @@ impl Xray {
                 mask.surface_geo.size.h as f32,
             );
             let clip_loc = Vec2::new(clip_geo.loc.x as f32, clip_geo.loc.y as f32);
-            let surface_loc = Vec2::new(
-                mask.surface_geo.loc.x as f32,
-                mask.surface_geo.loc.y as f32,
-            );
+            let surface_loc =
+                Vec2::new(mask.surface_geo.loc.x as f32, mask.surface_geo.loc.y as f32);
             let clip_size_v = Vec2::new(clip_geo.size.w as f32, clip_geo.size.h as f32);
-            // clip_to_surface(p) = (clip_geo.loc + p * clip_geo.size - surface_geo.loc) / surface_geo.size
+            // clip_to_surface(p) = (clip_geo.loc + p * clip_geo.size - surface_geo.loc) /
+            // surface_geo.size
             let m = Mat3::from_scale(Vec2::ONE / surface_size)
                 * Mat3::from_translation(clip_loc - surface_loc)
                 * Mat3::from_scale(clip_size_v);
@@ -218,11 +217,13 @@ impl Xray {
                 geometry.loc += params.geometry.loc;
 
                 let alpha_mask =
-                    clip_to_surface.as_ref().map(|(m, tex, threshold)| XrayAlphaMask {
-                        surface_tex: tex.clone(),
-                        surface_to_geo: *m * input_to_clip_geo,
-                        threshold: *threshold,
-                    });
+                    clip_to_surface
+                        .as_ref()
+                        .map(|(m, tex, threshold)| XrayAlphaMask {
+                            surface_tex: tex.clone(),
+                            surface_to_geo: *m * input_to_clip_geo,
+                            threshold: *threshold,
+                        });
 
                 let elem = XrayElement {
                     buffer: self.background[ctx.target as usize].clone(),
@@ -275,8 +276,9 @@ impl Xray {
             let input_to_clip_geo = Mat3::from_scale(buf_size / clip_geo_size)
                 * Mat3::from_translation(-clip_pos_in_backdrop / buf_size);
 
-            let alpha_mask =
-                clip_to_surface.as_ref().map(|(m, tex, threshold)| XrayAlphaMask {
+            let alpha_mask = clip_to_surface
+                .as_ref()
+                .map(|(m, tex, threshold)| XrayAlphaMask {
                     surface_tex: tex.clone(),
                     surface_to_geo: *m * input_to_clip_geo,
                     threshold: *threshold,
@@ -407,16 +409,8 @@ impl RenderElement<GlesRenderer> for XrayElement {
             frame.with_context(|gl| unsafe {
                 gl.ActiveTexture(ffi::TEXTURE1);
                 gl.BindTexture(ffi::TEXTURE_2D, tex_id);
-                gl.TexParameteri(
-                    ffi::TEXTURE_2D,
-                    ffi::TEXTURE_MIN_FILTER,
-                    ffi::LINEAR as i32,
-                );
-                gl.TexParameteri(
-                    ffi::TEXTURE_2D,
-                    ffi::TEXTURE_MAG_FILTER,
-                    ffi::LINEAR as i32,
-                );
+                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
+                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
                 gl.TexParameteri(
                     ffi::TEXTURE_2D,
                     ffi::TEXTURE_WRAP_S,

--- a/src/render_helpers/xray.rs
+++ b/src/render_helpers/xray.rs
@@ -6,7 +6,7 @@ use glam::{Mat3, Vec2};
 use niri_config::CornerRadius;
 use smithay::backend::renderer::element::{Element, Id, RenderElement};
 use smithay::backend::renderer::gles::{
-    GlesError, GlesFrame, GlesRenderer, GlesTexProgram, Uniform,
+    ffi, GlesError, GlesFrame, GlesRenderer, GlesTexProgram, GlesTexture, Uniform,
 };
 use smithay::backend::renderer::utils::{CommitCounter, OpaqueRegions};
 use smithay::backend::renderer::Color32F;
@@ -14,7 +14,7 @@ use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
-use crate::render_helpers::background_effect::RenderParams;
+use crate::render_helpers::background_effect::{AlphaMask, RenderParams};
 use crate::render_helpers::effect_buffer::EffectBuffer;
 use crate::render_helpers::renderer::AsGlesFrame as _;
 use crate::render_helpers::shaders::{mat3_uniform, Shaders};
@@ -81,6 +81,14 @@ pub struct XrayElement {
     saturation: f32,
     bg_color: Color32F,
     program: Option<GlesTexProgram>,
+    alpha_mask: Option<XrayAlphaMask>,
+}
+
+#[derive(Debug, Clone)]
+struct XrayAlphaMask {
+    surface_tex: GlesTexture,
+    surface_to_geo: Mat3,
+    threshold: f32,
 }
 
 impl Xray {
@@ -102,6 +110,7 @@ impl Xray {
         blur: bool,
         noise: f32,
         saturation: f32,
+        alpha_mask: Option<AlphaMask>,
         push: &mut dyn FnMut(XrayElement),
     ) {
         let program = Shaders::get(ctx.renderer).postprocess_and_clip.clone();
@@ -117,6 +126,27 @@ impl Xray {
         let clip_pos_in_backdrop = pos_in_backdrop + clip_offset.upscale(zoom);
 
         let geo_in_backdrop = Rectangle::new(pos_in_backdrop, params.geometry.size.upscale(zoom));
+
+        let clip_to_surface = alpha_mask.as_ref().and_then(|mask| {
+            if mask.surface_geo.size.w <= 0. || mask.surface_geo.size.h <= 0. {
+                return None;
+            }
+            let surface_size = Vec2::new(
+                mask.surface_geo.size.w as f32,
+                mask.surface_geo.size.h as f32,
+            );
+            let clip_loc = Vec2::new(clip_geo.loc.x as f32, clip_geo.loc.y as f32);
+            let surface_loc = Vec2::new(
+                mask.surface_geo.loc.x as f32,
+                mask.surface_geo.loc.y as f32,
+            );
+            let clip_size_v = Vec2::new(clip_geo.size.w as f32, clip_geo.size.h as f32);
+            // clip_to_surface(p) = (clip_geo.loc + p * clip_geo.size - surface_geo.loc) / surface_geo.size
+            let m = Mat3::from_scale(Vec2::ONE / surface_size)
+                * Mat3::from_translation(clip_loc - surface_loc)
+                * Mat3::from_scale(clip_size_v);
+            Some((m, mask.surface_tex.clone(), mask.threshold))
+        });
 
         let mut backdrop = self.backdrop[ctx.target as usize].borrow_mut();
         let backdrop_geo = Rectangle::from_size(backdrop.logical_size());
@@ -187,6 +217,13 @@ impl Xray {
                     Rectangle::new(crop.loc - geo_in_backdrop.loc, crop.size).downscale(zoom);
                 geometry.loc += params.geometry.loc;
 
+                let alpha_mask =
+                    clip_to_surface.as_ref().map(|(m, tex, threshold)| XrayAlphaMask {
+                        surface_tex: tex.clone(),
+                        surface_to_geo: *m * input_to_clip_geo,
+                        threshold: *threshold,
+                    });
+
                 let elem = XrayElement {
                     buffer: self.background[ctx.target as usize].clone(),
                     id: background.id().clone(),
@@ -202,6 +239,7 @@ impl Xray {
                     saturation,
                     bg_color: *bg_color,
                     program: program.clone(),
+                    alpha_mask,
                 };
                 push(elem);
             }
@@ -237,6 +275,13 @@ impl Xray {
             let input_to_clip_geo = Mat3::from_scale(buf_size / clip_geo_size)
                 * Mat3::from_translation(-clip_pos_in_backdrop / buf_size);
 
+            let alpha_mask =
+                clip_to_surface.as_ref().map(|(m, tex, threshold)| XrayAlphaMask {
+                    surface_tex: tex.clone(),
+                    surface_to_geo: *m * input_to_clip_geo,
+                    threshold: *threshold,
+                });
+
             let elem = XrayElement {
                 buffer: self.backdrop[ctx.target as usize].clone(),
                 id: backdrop.id().clone(),
@@ -252,6 +297,7 @@ impl Xray {
                 saturation,
                 bg_color: self.backdrop_color,
                 program: program.clone(),
+                alpha_mask,
             };
             push(elem);
         }
@@ -259,7 +305,12 @@ impl Xray {
 }
 
 impl XrayElement {
-    fn compute_uniforms(&self) -> [Uniform<'static>; 7] {
+    fn compute_uniforms(&self) -> [Uniform<'static>; 11] {
+        let (surface_to_geo, alpha_mask_enabled, alpha_threshold) = match &self.alpha_mask {
+            Some(mask) => (mask.surface_to_geo, 1i32, mask.threshold),
+            None => (Mat3::IDENTITY, 0i32, 0.0),
+        };
+
         [
             Uniform::new("niri_scale", self.scale),
             Uniform::new("geo_size", <[f32; 2]>::from(self.clip_geo_size)),
@@ -268,6 +319,11 @@ impl XrayElement {
             Uniform::new("noise", self.noise),
             Uniform::new("saturation", self.saturation),
             Uniform::new("bg_color", self.bg_color.components()),
+            mat3_uniform("surface_to_geo", surface_to_geo),
+            Uniform::new("alpha_mask_enabled", alpha_mask_enabled),
+            Uniform::new("alpha_threshold", alpha_threshold),
+            // Sampler uniform: read `surface_tex` from texture unit 1.
+            Uniform::new("surface_tex", 1i32),
         ]
     }
 }
@@ -342,7 +398,40 @@ impl RenderElement<GlesRenderer> for XrayElement {
         let uniforms = self.program.is_some().then(|| self.compute_uniforms());
         let uniforms = uniforms.as_ref().map_or(&[][..], |x| &x[..]);
 
-        frame.render_texture_from_to(
+        let surface_tex_id = self
+            .alpha_mask
+            .as_ref()
+            .filter(|_| self.program.is_some())
+            .map(|m| m.surface_tex.tex_id());
+        if let Some(tex_id) = surface_tex_id {
+            frame.with_context(|gl| unsafe {
+                gl.ActiveTexture(ffi::TEXTURE1);
+                gl.BindTexture(ffi::TEXTURE_2D, tex_id);
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_MIN_FILTER,
+                    ffi::LINEAR as i32,
+                );
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_MAG_FILTER,
+                    ffi::LINEAR as i32,
+                );
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_WRAP_S,
+                    ffi::CLAMP_TO_EDGE as i32,
+                );
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_WRAP_T,
+                    ffi::CLAMP_TO_EDGE as i32,
+                );
+                gl.ActiveTexture(ffi::TEXTURE0);
+            })?;
+        }
+
+        let result = frame.render_texture_from_to(
             &texture,
             src,
             dst,
@@ -353,7 +442,17 @@ impl RenderElement<GlesRenderer> for XrayElement {
             1.,
             self.program.as_ref(),
             uniforms,
-        )
+        );
+
+        if surface_tex_id.is_some() {
+            frame.with_context(|gl| unsafe {
+                gl.ActiveTexture(ffi::TEXTURE1);
+                gl.BindTexture(ffi::TEXTURE_2D, 0);
+                gl.ActiveTexture(ffi::TEXTURE0);
+            })?;
+        }
+
+        result
     }
 }
 

--- a/src/render_helpers/xray.rs
+++ b/src/render_helpers/xray.rs
@@ -14,11 +14,11 @@ use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
-use crate::render_helpers::background_effect::{AlphaMask, RenderParams};
+use crate::render_helpers::background_effect::{AlphaMask, RenderParams, ALPHA_MASK_UNIT};
 use crate::render_helpers::effect_buffer::EffectBuffer;
 use crate::render_helpers::renderer::AsGlesFrame as _;
 use crate::render_helpers::shaders::{mat3_uniform, Shaders};
-use crate::render_helpers::{RenderCtx, RenderTarget};
+use crate::render_helpers::{aux_texture, RenderCtx, RenderTarget};
 use crate::utils::region::TransformedRegion;
 
 #[derive(Debug)]
@@ -141,7 +141,8 @@ impl Xray {
             let clip_size_v = Vec2::new(clip_geo.size.w as f32, clip_geo.size.h as f32);
             // clip_to_surface(p) = (clip_geo.loc + p * clip_geo.size - surface_geo.loc) /
             // surface_geo.size
-            let m = Mat3::from_scale(Vec2::ONE / surface_size)
+            let m = mask.geo_to_uv()
+                * Mat3::from_scale(Vec2::ONE / surface_size)
                 * Mat3::from_translation(clip_loc - surface_loc)
                 * Mat3::from_scale(clip_size_v);
             Some((m, mask.surface_tex.clone(), mask.threshold))
@@ -324,8 +325,7 @@ impl XrayElement {
             mat3_uniform("surface_to_geo", surface_to_geo),
             Uniform::new("alpha_mask_enabled", alpha_mask_enabled),
             Uniform::new("alpha_threshold", alpha_threshold),
-            // Sampler uniform: read `surface_tex` from texture unit 1.
-            Uniform::new("surface_tex", 1i32),
+            Uniform::new("surface_tex", ALPHA_MASK_UNIT as i32),
         ]
     }
 }
@@ -407,21 +407,7 @@ impl RenderElement<GlesRenderer> for XrayElement {
             .map(|m| m.surface_tex.tex_id());
         if let Some(tex_id) = surface_tex_id {
             frame.with_context(|gl| unsafe {
-                gl.ActiveTexture(ffi::TEXTURE1);
-                gl.BindTexture(ffi::TEXTURE_2D, tex_id);
-                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
-                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
-                gl.TexParameteri(
-                    ffi::TEXTURE_2D,
-                    ffi::TEXTURE_WRAP_S,
-                    ffi::CLAMP_TO_EDGE as i32,
-                );
-                gl.TexParameteri(
-                    ffi::TEXTURE_2D,
-                    ffi::TEXTURE_WRAP_T,
-                    ffi::CLAMP_TO_EDGE as i32,
-                );
-                gl.ActiveTexture(ffi::TEXTURE0);
+                aux_texture::bind(gl, ALPHA_MASK_UNIT, tex_id, ffi::CLAMP_TO_EDGE);
             })?;
         }
 
@@ -439,11 +425,7 @@ impl RenderElement<GlesRenderer> for XrayElement {
         );
 
         if surface_tex_id.is_some() {
-            frame.with_context(|gl| unsafe {
-                gl.ActiveTexture(ffi::TEXTURE1);
-                gl.BindTexture(ffi::TEXTURE_2D, 0);
-                gl.ActiveTexture(ffi::TEXTURE0);
-            })?;
+            frame.with_context(|gl| unsafe { aux_texture::unbind(gl, ALPHA_MASK_UNIT) })?;
         }
 
         result


### PR DESCRIPTION
Lands #23 (a copy of upstream niri-wm/niri#4105 by @Fexaop) on `barrulus-custom`, which is where fork changes go; `main` is kept as a pristine upstream mirror. The author's commits are merged as-is, followed by fork-side fixes.

## What it does

`ignore-opacity` in `layer-rule` / `window-rule` `background-effect` masks the blurred or xray backdrop by the surface's own alpha, so fully transparent regions of a big layer (a full-screen shell layer with a small bar, notification stacks, launchers) show the unblurred content beneath. Accepts `true` (threshold `0.0`), `false`, or a threshold in `[0.0, 1.0]`.

It is a compositor-side workaround for clients that do not declare a blur region via ext-background-effect-v1. It does not reduce blur cost; it discards fragments after the fact. Dormant unless configured: no surface import, texture clone or extra GL binding happens when the option is unset.

## Fork-side fixes on top of #23

- Import `gles::ffi` in `framebuffer_effect.rs`; upstream already has it, the fork's copy predated it, so #23 did not compile here.
- Resolve the `pub use crate::utils` conflict in `niri-config/src/lib.rs`.
- Add a parse/merge test covering `true`, `false`, floats, integer `1`, window rules, and rejected values (`1.5`, `-0.1`, `2`, strings, `null`).
- Document the option for window rules too (the rule struct is shared) and note its limitations in the layer-rule docs.
- New `render_helpers::aux_texture` with `bind`/`unbind`, replacing three hand-rolled copies of the same GL calls (`ShaderRenderElement`, `FramebufferEffectElement`, `XrayElement`).
- `AlphaMask::geo_to_uv()` flips V for y-inverted surface textures so dmabuf/EGL-backed layers mask correctly.

## Known limitation

The mask binds the client texture as `TEXTURE_2D`. Smithay's `is_external` flag is private, so a buffer imported as `TEXTURE_EXTERNAL_OES` cannot be detected; it would sample as black and disable blur for that surface rather than crash. Subsurfaces and viewport source crops are not considered.

## Testing

- `cargo build`, `cargo clippy`, `cargo fmt --check` clean.
- `cargo test -p niri-config`: 48 passed.
- Not yet hardware-tested; needs a run with a dmabuf-backed layer (Quickshell/DMS) and a shm one (Waybar) before merge.