### PR TITLE
Keep index-based workspace moves out of the hidden block

### DIFF
--- a/docs/wiki/Configuration:-Named-Workspaces.md
+++ b/docs/wiki/Configuration:-Named-Workspaces.md
@@ -135,4 +135,8 @@ niri msg action unhide-workspace scratch --focus true
 Focusing a hidden workspace by name with `focus-workspace "name"` shows it temporarily: it hides itself again as soon as you switch away.
 Use `unhide-workspace` (or `toggle-workspace-visibility`) when you want it to stay visible.
 
+A hidden workspace is only reachable by name (or by id over IPC).
+Numeric workspace indices address the visible workspaces only, so `focus-workspace 3`, `move-window-to-workspace 3` and `move-column-to-workspace 3` never land on a hidden workspace.
+An index past the last visible workspace clamps to it, exactly as it does when no workspace is hidden.
+
 `niri msg workspaces` reports the hidden state of each workspace in the `is_hidden` field, so scripts can decide between `hide-workspace` and `unhide-workspace` instead of toggling.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1387,6 +1387,9 @@ impl State {
                 self.niri.queue_redraw_all();
             }
             Action::MoveWindowToWorkspace(reference, focus) => {
+                // A plain workspace index addresses the visible region; only a name or id
+                // may pick out a hidden workspace.
+                let allow_hidden = !matches!(reference, WorkspaceReference::Index(_));
                 if let Some((mut output, index)) =
                     self.niri.find_output_and_workspace_index(reference)
                 {
@@ -1417,7 +1420,9 @@ impl State {
                             self.maybe_warp_cursor_to_focus();
                         }
                     } else {
-                        self.niri.layout.move_to_workspace(None, index, activate);
+                        self.niri
+                            .layout
+                            .move_to_workspace(None, index, activate, allow_hidden);
                         self.maybe_warp_cursor_to_focus();
                     }
 
@@ -1433,6 +1438,9 @@ impl State {
                 let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
                 let window = window.map(|(_, m)| m.window.clone());
                 if let Some(window) = window {
+                    // A plain workspace index addresses the visible region; only a name or
+                    // id may pick out a hidden workspace.
+                    let allow_hidden = !matches!(reference, WorkspaceReference::Index(_));
                     if let Some((output, index)) =
                         self.niri.find_output_and_workspace_index(reference)
                     {
@@ -1466,9 +1474,12 @@ impl State {
                                 }
                             }
                         } else {
-                            self.niri
-                                .layout
-                                .move_to_workspace(Some(&window), index, activate);
+                            self.niri.layout.move_to_workspace(
+                                Some(&window),
+                                index,
+                                activate,
+                                allow_hidden,
+                            );
 
                             // If we focused the target window.
                             let new_focus = self.niri.layout.focus();
@@ -1495,6 +1506,9 @@ impl State {
                 self.niri.queue_redraw_all();
             }
             Action::MoveColumnToWorkspace(reference, focus) => {
+                // A plain workspace index addresses the visible region; only a name or id
+                // may pick out a hidden workspace.
+                let allow_hidden = !matches!(reference, WorkspaceReference::Index(_));
                 if let Some((mut output, index)) =
                     self.niri.find_output_and_workspace_index(reference)
                 {
@@ -1512,7 +1526,9 @@ impl State {
                             self.move_cursor_to_output(&output);
                         }
                     } else {
-                        self.niri.layout.move_column_to_workspace(index, focus);
+                        self.niri
+                            .layout
+                            .move_column_to_workspace(index, focus, allow_hidden);
                         if focus {
                             self.maybe_warp_cursor_to_focus();
                         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1561,8 +1561,11 @@ impl<W: LayoutElement> Layout<W> {
     ) -> Option<&mut Workspace<W>> {
         if let WorkspaceReference::Index(index) = reference {
             self.active_monitor().and_then(|m| {
+                // A plain workspace index addresses the visible region; hidden workspaces
+                // sit past its end and are only reachable by name or id.
+                let visible_count = m.visible_workspace_count();
                 let index = index.saturating_sub(1) as usize;
-                m.workspaces.get_mut(index)
+                (index < visible_count).then(|| &mut m.workspaces[index])
             })
         } else {
             self.workspaces_mut().find(|ws| match &reference {
@@ -2914,11 +2917,15 @@ impl<W: LayoutElement> Layout<W> {
         monitor.move_to_workspace_down(activate);
     }
 
+    /// Moves a window to the workspace at `idx` on its own monitor.
+    ///
+    /// See [`Monitor::move_to_workspace`] for `allow_hidden`.
     pub fn move_to_workspace(
         &mut self,
         window: Option<&W::Id>,
         idx: usize,
         activate: ActivateWindow,
+        allow_hidden: bool,
     ) {
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             if window.is_none() || window == Some(move_.tile.window().id()) {
@@ -2953,7 +2960,7 @@ impl<W: LayoutElement> Layout<W> {
             };
             monitor
         };
-        monitor.move_to_workspace(window, idx, activate);
+        monitor.move_to_workspace(window, idx, activate, allow_hidden);
     }
 
     pub fn move_column_to_workspace_up(&mut self, activate: bool) {
@@ -2970,11 +2977,14 @@ impl<W: LayoutElement> Layout<W> {
         monitor.move_column_to_workspace_down(activate);
     }
 
-    pub fn move_column_to_workspace(&mut self, idx: usize, activate: bool) {
+    /// Moves the active column to the workspace at `idx` on the active monitor.
+    ///
+    /// See [`Monitor::move_to_workspace`] for `allow_hidden`.
+    pub fn move_column_to_workspace(&mut self, idx: usize, activate: bool, allow_hidden: bool) {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.move_column_to_workspace(idx, activate);
+        monitor.move_column_to_workspace(idx, activate, allow_hidden);
     }
 
     pub fn switch_workspace_up(&mut self) {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1291,7 +1291,7 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn move_to_workspace_up(&mut self, activate: ActivateWindow) {
         let new_idx = self.active_workspace_idx.saturating_sub(1);
-        self.move_to_workspace(None, new_idx, activate);
+        self.move_to_workspace(None, new_idx, activate, false);
     }
 
     pub fn move_to_workspace_down(&mut self, activate: ActivateWindow) {
@@ -1302,14 +1302,36 @@ impl<W: LayoutElement> Monitor<W> {
             .position(|ws| ws.hidden)
             .unwrap_or(self.workspaces.len());
         let new_idx = min(self.active_workspace_idx + 1, visible_end - 1);
-        self.move_to_workspace(None, new_idx, activate);
+        self.move_to_workspace(None, new_idx, activate, false);
     }
 
+    /// Clamps a move target index to the range it is allowed to address.
+    ///
+    /// Hidden workspaces are contiguous at the end of the workspace vec, so clamping a
+    /// too-large index against the whole vec would land it on the first hidden workspace
+    /// instead of the last visible one. Only name- and id-based references may address
+    /// the hidden block.
+    fn clamp_target_workspace_idx(&self, idx: usize, allow_hidden: bool) -> usize {
+        let len = if allow_hidden {
+            self.workspaces.len()
+        } else {
+            self.visible_workspace_count()
+        };
+        min(idx, len - 1)
+    }
+
+    /// Moves a window to the workspace at `idx`.
+    ///
+    /// `allow_hidden` says whether `idx` is allowed to address the hidden block. Only a
+    /// reference that picks out a specific workspace (by name or by id) may; a plain
+    /// workspace index addresses the visible region, so it clamps to the last visible
+    /// workspace instead.
     pub fn move_to_workspace(
         &mut self,
         window: Option<&W::Id>,
         idx: usize,
         activate: ActivateWindow,
+        allow_hidden: bool,
     ) {
         let source_workspace_idx = if let Some(window) = window {
             self.workspaces
@@ -1321,7 +1343,7 @@ impl<W: LayoutElement> Monitor<W> {
         };
         let source_id = self.workspaces[source_workspace_idx].id();
 
-        let new_idx = min(idx, self.workspaces.len() - 1);
+        let new_idx = self.clamp_target_workspace_idx(idx, allow_hidden);
         if new_idx == source_workspace_idx {
             return;
         }
@@ -1400,7 +1422,7 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn move_column_to_workspace_up(&mut self, activate: bool) {
         let new_idx = self.active_workspace_idx.saturating_sub(1);
-        self.move_column_to_workspace(new_idx, activate);
+        self.move_column_to_workspace(new_idx, activate, false);
     }
 
     pub fn move_column_to_workspace_down(&mut self, activate: bool) {
@@ -1411,13 +1433,16 @@ impl<W: LayoutElement> Monitor<W> {
             .position(|ws| ws.hidden)
             .unwrap_or(self.workspaces.len());
         let new_idx = min(self.active_workspace_idx + 1, visible_end - 1);
-        self.move_column_to_workspace(new_idx, activate);
+        self.move_column_to_workspace(new_idx, activate, false);
     }
 
-    pub fn move_column_to_workspace(&mut self, idx: usize, activate: bool) {
+    /// Moves the active column to the workspace at `idx`.
+    ///
+    /// See [`Monitor::move_to_workspace`] for `allow_hidden`.
+    pub fn move_column_to_workspace(&mut self, idx: usize, activate: bool, allow_hidden: bool) {
         let source_workspace_idx = self.active_workspace_idx;
 
-        let new_idx = min(idx, self.workspaces.len() - 1);
+        let new_idx = self.clamp_target_workspace_idx(idx, allow_hidden);
         if new_idx == source_workspace_idx {
             return;
         }
@@ -1429,7 +1454,7 @@ impl<W: LayoutElement> Monitor<W> {
             } else {
                 ActivateWindow::No
             };
-            self.move_to_workspace(None, idx, activate);
+            self.move_to_workspace(None, new_idx, activate, allow_hidden);
             return;
         }
 

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -531,10 +531,11 @@ enum Op {
         window_id: Option<usize>,
         #[proptest(strategy = "0..=4usize")]
         workspace_idx: usize,
+        allow_hidden: bool,
     },
     MoveColumnToWorkspaceDown(bool),
     MoveColumnToWorkspaceUp(bool),
-    MoveColumnToWorkspace(#[proptest(strategy = "0..=4usize")] usize, bool),
+    MoveColumnToWorkspace(#[proptest(strategy = "0..=4usize")] usize, bool, bool),
     MoveWorkspaceDown,
     MoveWorkspaceUp,
     MoveWorkspaceToIndex {
@@ -1212,13 +1213,21 @@ impl Op {
             Op::MoveWindowToWorkspace {
                 window_id,
                 workspace_idx,
+                allow_hidden,
             } => {
                 let window_id = window_id.filter(|id| layout.has_window(id));
-                layout.move_to_workspace(window_id.as_ref(), workspace_idx, ActivateWindow::Smart);
+                layout.move_to_workspace(
+                    window_id.as_ref(),
+                    workspace_idx,
+                    ActivateWindow::Smart,
+                    allow_hidden,
+                );
             }
             Op::MoveColumnToWorkspaceDown(focus) => layout.move_column_to_workspace_down(focus),
             Op::MoveColumnToWorkspaceUp(focus) => layout.move_column_to_workspace_up(focus),
-            Op::MoveColumnToWorkspace(idx, focus) => layout.move_column_to_workspace(idx, focus),
+            Op::MoveColumnToWorkspace(idx, focus, allow_hidden) => {
+                layout.move_column_to_workspace(idx, focus, allow_hidden)
+            }
             Op::MoveWindowToOutput {
                 window_id,
                 output_id: id,
@@ -1813,6 +1822,7 @@ fn move_window_to_hidden_workspace_with_empty_above_first() {
         Op::MoveWindowToWorkspace {
             window_id: None,
             workspace_idx: 3,
+            allow_hidden: true,
         },
         Op::FocusWorkspaceDown,
     ]);
@@ -1856,7 +1866,7 @@ fn focus_after_column_move_unhides_workspace() {
         Op::AddWindow {
             params: TestWindowParams::new(1),
         },
-        Op::MoveColumnToWorkspace(2, true),
+        Op::MoveColumnToWorkspace(2, true, true),
         Op::FocusWorkspace(2),
     ]);
 }
@@ -2006,8 +2016,72 @@ fn move_column_into_hidden_workspace() {
         },
         Op::AddOutput(1),
         Op::ToggleWorkspaceVisibility(4),
-        Op::MoveColumnToWorkspace(2, true),
+        Op::MoveColumnToWorkspace(2, true, true),
     ]);
+}
+
+#[test]
+fn move_column_to_workspace_index_past_visible_end_stays_visible() {
+    // https://github.com/barrulus/biri/issues/31: a workspace index past the end of the
+    // visible region must clamp to the last visible workspace. Clamping against the whole
+    // workspace vec would land the column on the first hidden workspace instead (and
+    // force-unhide it, since focus follows).
+    let layout = check_ops([
+        Op::AddNamedWorkspace {
+            ws_name: 1,
+            output_name: None,
+            layout_config: None,
+        },
+        Op::AddOutput(1),
+        Op::ToggleWorkspaceVisibility(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::MoveColumnToWorkspace(4, true, false),
+    ]);
+
+    assert_window_stayed_visible(&layout);
+}
+
+#[test]
+fn move_window_to_workspace_index_past_visible_end_stays_visible() {
+    // Same as above for move-window-to-workspace.
+    let layout = check_ops([
+        Op::AddNamedWorkspace {
+            ws_name: 1,
+            output_name: None,
+            layout_config: None,
+        },
+        Op::AddOutput(1),
+        Op::ToggleWorkspaceVisibility(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::MoveWindowToWorkspace {
+            window_id: Some(1),
+            workspace_idx: 4,
+            allow_hidden: false,
+        },
+    ]);
+
+    assert_window_stayed_visible(&layout);
+}
+
+fn assert_window_stayed_visible(layout: &Layout<TestWindow>) {
+    let (_, _, ws) = layout
+        .workspaces()
+        .find(|(_, _, ws)| ws.has_window(&1))
+        .expect("window 1 must still exist");
+    assert!(
+        !ws.hidden,
+        "window must not land in the hidden block: index-based moves address \
+         the visible region"
+    );
+
+    let hidden = layout
+        .workspaces()
+        .find_map(|(_, _, ws)| (ws.name() == Some(&"ws1".to_string())).then_some(ws.hidden));
+    assert_eq!(hidden, Some(true), "ws1 must remain hidden");
 }
 
 #[test]
@@ -2112,6 +2186,7 @@ fn move_window_into_hidden_workspace_then_move_workspace_down() {
         Op::MoveWindowToWorkspace {
             window_id: None,
             workspace_idx: 2,
+            allow_hidden: true,
         },
         Op::MoveWorkspaceDown,
     ]);
@@ -2624,15 +2699,17 @@ fn operations_dont_panic() {
         Op::MoveWindowToWorkspace {
             window_id: None,
             workspace_idx: 1,
+            allow_hidden: true,
         },
         Op::MoveWindowToWorkspace {
             window_id: None,
             workspace_idx: 2,
+            allow_hidden: true,
         },
         Op::MoveColumnToWorkspaceDown(true),
         Op::MoveColumnToWorkspaceUp(true),
-        Op::MoveColumnToWorkspace(1, true),
-        Op::MoveColumnToWorkspace(2, true),
+        Op::MoveColumnToWorkspace(1, true, true),
+        Op::MoveColumnToWorkspace(2, true, true),
         Op::MoveWindowDown,
         Op::MoveWindowDownOrToWorkspaceDown,
         Op::MoveWindowUp,
@@ -2801,20 +2878,23 @@ fn operations_from_starting_state_dont_panic() {
         Op::MoveWindowToWorkspace {
             window_id: None,
             workspace_idx: 1,
+            allow_hidden: true,
         },
         Op::MoveWindowToWorkspace {
             window_id: None,
             workspace_idx: 2,
+            allow_hidden: true,
         },
         Op::MoveWindowToWorkspace {
             window_id: None,
             workspace_idx: 3,
+            allow_hidden: true,
         },
         Op::MoveColumnToWorkspaceDown(true),
         Op::MoveColumnToWorkspaceUp(true),
-        Op::MoveColumnToWorkspace(1, true),
-        Op::MoveColumnToWorkspace(2, true),
-        Op::MoveColumnToWorkspace(3, true),
+        Op::MoveColumnToWorkspace(1, true, true),
+        Op::MoveColumnToWorkspace(2, true, true),
+        Op::MoveColumnToWorkspace(3, true, true),
         Op::MoveWindowDown,
         Op::MoveWindowDownOrToWorkspaceDown,
         Op::MoveWindowUp,
@@ -2919,6 +2999,7 @@ fn move_to_workspace_by_idx_does_not_leave_empty_workspaces() {
         Op::MoveWindowToWorkspace {
             window_id: Some(0),
             workspace_idx: 2,
+            allow_hidden: true,
         },
     ];
 
@@ -4119,6 +4200,7 @@ fn move_window_to_workspace_with_different_active_output() {
         Op::MoveWindowToWorkspace {
             window_id: Some(0),
             workspace_idx: 2,
+            allow_hidden: true,
         },
     ];
 
@@ -4403,7 +4485,7 @@ fn move_column_to_workspace_focus_false_on_floating_window() {
             params: TestWindowParams::new(2),
         },
         Op::ToggleWindowFloating { id: None },
-        Op::MoveColumnToWorkspace(1, false),
+        Op::MoveColumnToWorkspace(1, false, true),
     ];
 
     let layout = check_ops(ops);

--- a/src/layout/tests/fullscreen.rs
+++ b/src/layout/tests/fullscreen.rs
@@ -272,6 +272,7 @@ fn move_unfocused_pending_unfullscreen_window_out_of_active_column() {
         Op::MoveWindowToWorkspace {
             window_id: Some(1),
             workspace_idx: 1,
+            allow_hidden: true,
         },
     ];
 


### PR DESCRIPTION
Fixes #31.

## The bug

With a hidden workspace configured, moving a window or column to a workspace index past the last visible workspace dumped it into the hidden workspace and — because focus follows the move — force-unhid it. From the outside this is indistinguishable from having run `toggle-workspace-visibility`, which is exactly how the reporter described it.

The reporter's `Mod+Shift+o` → `move-column-to-workspace 99` binding hit this on every press, not just at the boundary.

## Root cause

Hidden workspaces are contiguous at the **end** of `Monitor::workspaces`. `move_to_workspace` and `move_column_to_workspace` clamped their target with `min(idx, self.workspaces.len() - 1)`, so an out-of-range index clamped onto the first hidden workspace rather than the last visible one.

`switch_workspace` already guarded against this — it clamps and then walks *back* to the last non-hidden workspace — which is why `focus-workspace N` was unaffected and only the move actions misbehaved. The relative variants (`move-*-to-workspace-down`) were also already correct; only the absolute-index paths were missed.

The reporter's second monitor behaved correctly because its hidden workspace lived on the other output, leaving no hidden block for the clamp to land in.

## The fix

A workspace index addresses the visible region only. Hidden workspaces stay reachable by name and by id, so scratchpad-style `move-window-to-workspace "stash"` still works.

- `Monitor::clamp_target_workspace_idx(idx, allow_hidden)`, built on the existing `visible_workspace_count()`, replaces both raw clamps.
- `allow_hidden` is threaded through the `Monitor` and `Layout` move functions and set in the action handlers from the reference kind (`!matches!(reference, WorkspaceReference::Index(_))`). The relative up/down variants pass `false`.
- `Layout::find_workspace_by_ref` had the same raw indexing, letting `unname-workspace 3` and `set-workspace-name` by index target a hidden workspace. It now rejects indices past the visible region.
- Documented the index semantics in the named-workspaces wiki page.

## Testing

Two regression tests reproduce the report: a named hidden workspace plus a move to index 4 with only two visible workspaces. Flipping `allow_hidden` back to `true` makes both fail with the reported symptom:

```
assertion `left == right` failed: ws1 must remain hidden
  left: Some(false)   right: Some(true)
```

- Full lib suite: 285 passed.
- `RUN_SLOW_TESTS=1 PROPTEST_CASES=4000` on the layout proptest: passed. The test ops carry `allow_hidden`, so proptest explores both paths.
- Existing hidden-workspace regressions pass `allow_hidden: true` so they keep exercising the force-unhide path they were minimized for.
- `cargo fmt --check` clean; no new clippy warnings.

Not hardware-tested yet.
