### PR TITLE
Multi-action binds: several actions per bind, and an atomic IPC action batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "sd-notify",
  "serde",
  "serde_json",
+ "shlex 1.3.0",
  "smithay",
  "smithay-drm-extras",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ profiling = "1.0.18"
 sd-notify = "0.5.0"
 serde.workspace = true
 serde_json.workspace = true
+shlex = "1.3"
 smithay-drm-extras.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true

--- a/docs/superpowers/plans/2026-09-06-multi-action-binds.md
+++ b/docs/superpowers/plans/2026-09-06-multi-action-binds.md
@@ -1,0 +1,1065 @@
+# Multi-Action Binds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let one keybind run several actions in order, and let one IPC request run several actions as a single uninterruptible batch.
+
+**Architecture:** `Bind.action: Action` becomes `Bind.actions: Vec<Action>`, matching the shape upstream (YaLTeR, bbb651) already agreed on so this can be offered to niri later. Task 1 is a pure type refactor with no behaviour change; Task 2 turns on multi-action parsing; Tasks 3 and 4 add the IPC batch and its CLI front end. Every fold over the new list (`all` vs `any`) is specified explicitly, because two of them are security-relevant.
+
+**Tech Stack:** Rust (nightly via devshell), `knuffel` for KDL config decoding, `clap` for the CLI, `serde` for the IPC protocol, `insta` for config snapshot tests.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-multi-action-binds-design.md`
+
+## Global Constraints
+
+- **Build and test only through the devshell.** From `/home/barrulus/dev/biri`, run every cargo command as `direnv exec . bash -c '<cmd>'`. Do **not** use `nix develop ...--command`: it changes `PKG_CONFIG_*`/`BINDGEN_*` env vars that feed cargo build-script fingerprints and forces a fresh `libspa-sys`/`pipewire-sys` bindgen.
+- The devshell toolchain is nightly by default. **Never** prefix `+nightly` — rustup is not the driver and `cargo +nightly` errors.
+- Branch: `multi-action-binds`, already created off `origin/main` at `2e076c89`.
+- **No AI attribution** in commit messages. No `Co-Authored-By` lines, no "Generated with" trailers.
+- `cargo insta accept` has hung on this repo. Hand-edit inline snapshots instead; if a snapshot diff is unexpectedly large, inspect `niri-config/src/.lib.rs.pending-snap` rather than reaching for `insta accept`.
+- Upstream decisions adopted verbatim, do not re-litigate: the hotkey overlay ignores multi-action binds; the CLI gets a separate `Actions` variant; a failed `allow-when-locked` check skips just that action; no `or` combinator.
+
+---
+
+### Task 1: Refactor `Bind.action` to `Bind.actions: Vec<Action>`
+
+Pure type change. The parser still rejects two or more actions per bind, so **no observable behaviour changes** and every existing test must still pass unmodified in intent. The folds introduced here are all no-ops for a one-element list, which is what makes them safe to land before the feature.
+
+**Files:**
+- Modify: `niri-config/src/binds.rs:23-31` (struct), `:925-980` (dummy bind + `Ok(Self { .. })` construction), `:1101-1116` (existing test)
+- Modify: `niri-config/src/lib.rs:714` (test), plus 18 inline-snapshot blocks at lines 2178, 2198, 2214, 2234, 2252, 2268, 2286, 2302, 2320, 2338, 2354, 2374, 2394, 2412, 2428, 2551, 2573, 2595
+- Modify: `src/input/mod.rs:685-716` (`handle_bind`), 11 `allowed_during_screenshot(&bind.action)` sites at lines 3159, 3574, 3584, 3686, 3692, 3839, 3845, 3877, 3883, 4299, 4928, and 19 `Bind { .. }` literals
+- Modify: `src/ui/mru.rs:1848-1865` (`make_preset_opened_binds`), `:1902-1934` (`make_dynamic_opened_binds`)
+- Modify: `src/ui/hotkey_overlay.rs:155-194` (`format_bind`), `:197-260` (`collect_actions`)
+
+**Interfaces:**
+- Produces: `niri_config::Bind { key: Key, actions: Vec<Action>, repeat: bool, cooldown: Option<Duration>, allow_when_locked: bool, allow_inhibiting: bool, hotkey_overlay_title: Option<Option<String>> }`
+- Produces: `State::do_actions(&mut self, actions: Vec<Action>, allow_when_locked: bool)` in `src/input/mod.rs`
+- Produces: `fn bind_allowed_during_screenshot(bind: &Bind) -> bool` in `src/input/mod.rs`
+
+- [ ] **Step 1: Record the baseline**
+
+Run the suite before touching anything, so a later failure is unambiguous.
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test 2>&1 | tail -30'
+```
+
+Expected: all tests pass. Save the summary line (e.g. `test result: ok. N passed`) — Step 12 must match it.
+
+- [ ] **Step 2: Change the struct field**
+
+`niri-config/src/binds.rs`, replace lines 23-31:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct Bind {
+    pub key: Key,
+    pub actions: Vec<Action>,
+    pub repeat: bool,
+    pub cooldown: Option<Duration>,
+    pub allow_when_locked: bool,
+    pub allow_inhibiting: bool,
+    pub hotkey_overlay_title: Option<Option<String>>,
+}
+```
+
+- [ ] **Step 3: Update the decoder's two construction sites**
+
+Still one action only — this step does not add the feature. In `Bind::decode_node`, the dummy (around line 933) becomes:
+
+```rust
+        let dummy = Self {
+            key,
+            actions: Vec::new(),
+            repeat: true,
+            cooldown: None,
+            allow_when_locked: false,
+            allow_inhibiting: true,
+            hotkey_overlay_title: None,
+        };
+```
+
+and the success construction (around line 962) becomes:
+
+```rust
+                    Ok(Self {
+                        key,
+                        actions: vec![action],
+                        repeat,
+                        cooldown,
+                        allow_when_locked,
+                        allow_inhibiting,
+                        hotkey_overlay_title,
+                    })
+```
+
+Leave the `"only one action is allowed per keybind"` error at line 940 in place. Task 2 removes it.
+
+- [ ] **Step 4: Rewrite `handle_bind` to loop, and add `do_actions`**
+
+`src/input/mod.rs`, replace `handle_bind` (lines 685-716) with:
+
+```rust
+    pub fn handle_bind(&mut self, bind: Bind) {
+        let Some(cooldown) = bind.cooldown else {
+            self.do_actions(bind.actions, bind.allow_when_locked);
+            return;
+        };
+
+        // Check this first so that it doesn't trigger the cooldown.
+        //
+        // Run the bind if *any* of its actions would be allowed; do_action skips the rest
+        // individually.
+        if self.niri.is_locked()
+            && !(bind.allow_when_locked || bind.actions.iter().any(allowed_when_locked))
+        {
+            return;
+        }
+
+        match self.niri.bind_cooldown_timers.entry(bind.key) {
+            // The bind is on cooldown.
+            Entry::Occupied(_) => (),
+            Entry::Vacant(entry) => {
+                let timer = Timer::from_duration(cooldown);
+                let token = self
+                    .niri
+                    .event_loop
+                    .insert_source(timer, move |_, _, state| {
+                        if state.niri.bind_cooldown_timers.remove(&bind.key).is_none() {
+                            error!("bind cooldown timer entry disappeared");
+                        }
+                        TimeoutAction::Drop
+                    })
+                    .unwrap();
+                entry.insert(token);
+
+                self.do_actions(bind.actions, bind.allow_when_locked);
+            }
+        }
+    }
+
+    pub fn do_actions(&mut self, actions: Vec<Action>, allow_when_locked: bool) {
+        for action in actions {
+            self.do_action(action, allow_when_locked);
+        }
+    }
+```
+
+The `move` closure captures only `bind.key` (Rust 2021 disjoint capture, and `Key` is `Copy`), so `bind.actions` is still owned and usable afterwards. `do_action` itself is unchanged: it keeps its `Action` signature and its own per-action lock check.
+
+- [ ] **Step 5: Add the screenshot fold helper**
+
+`src/input/mod.rs`, immediately after the existing `allowed_during_screenshot` function (which ends around line 5215), add:
+
+```rust
+/// A bind is usable while the screenshot UI is open only if *every* one of its actions is.
+/// The screenshot UI must never be handed a bind it can only half-run.
+fn bind_allowed_during_screenshot(bind: &Bind) -> bool {
+    bind.actions.iter().all(allowed_during_screenshot)
+}
+```
+
+- [ ] **Step 6: Point the 11 screenshot call sites at the helper**
+
+```bash
+cd /home/barrulus/dev/biri
+sed -i 's/allowed_during_screenshot(&bind\.action)/bind_allowed_during_screenshot(\&bind)/g' src/input/mod.rs
+grep -c 'bind_allowed_during_screenshot(&bind)' src/input/mod.rs
+```
+
+Expected: `11`. If the count differs, stop and inspect — do not proceed.
+
+Some sites hold `bind` by reference already; if the compiler complains about `&&bind` at any site in Step 10, drop the extra `&` there.
+
+- [ ] **Step 7: Update the 19 synthetic `Bind` literals in `src/input/mod.rs`**
+
+There are **19** `Bind { .. }` literals in this file, each with an `action: X,` field that becomes `actions: vec![X],`. List them and their fields with:
+
+```bash
+cd /home/barrulus/dev/biri
+grep -c 'Bind {' src/input/mod.rs   # expect 19
+grep -n 'action:' src/input/mod.rs
+```
+
+Work through every `action:` hit that sits inside a `Bind { .. }` literal (skip `OutputAction`/`SwitchAction` hits). Step 10's build is the backstop: any literal missed here becomes a compile error naming its line. For example, the screenshot-UI bind around line 4935:
+
+```rust
+                final_bind = screenshot_ui.action(raw, mods).map(|action| Bind {
+                    key: Key {
+                        trigger: Trigger::Keysym(raw),
+                        modifiers: mods,
+                    },
+                    actions: vec![action],
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: false,
+                    hotkey_overlay_title: None,
+                });
+```
+
+- [ ] **Step 8: Update `src/ui/mru.rs`**
+
+In `make_preset_opened_binds` (line ~1852), the `push` closure builds a `Bind`:
+
+```rust
+    let mut push = |trigger, action| {
+        rv.push(Bind {
+            key: Key {
+                trigger: Trigger::Keysym(trigger),
+                // The modifier is filled dynamically.
+                modifiers: Modifiers::empty(),
+            },
+            actions: vec![action],
+            repeat: true,
+            cooldown: None,
+            allow_when_locked: false,
+            allow_inhibiting: false,
+            hotkey_overlay_title: None,
+        })
+    };
+```
+
+In `make_dynamic_opened_binds` (line ~1906), only single-action binds map to an MRU action — a multi-action bind must not silently become an MRU navigation bind:
+
+```rust
+    for bind in &config.binds.0 {
+        // Multi-action binds don't map onto a single MRU action.
+        let [bind_action] = bind.actions.as_slice() else {
+            continue;
+        };
+
+        let action = match bind_action {
+            Action::FocusColumnRight
+            | Action::FocusColumnRightOrFirst
+            | Action::FocusColumnOrMonitorRight
+            | Action::FocusWindowDownOrColumnRight => Action::MruAdvance {
+                direction: MruDirection::Forward,
+                scope: None,
+                filter: None,
+            },
+            Action::FocusColumnLeft
+            | Action::FocusColumnLeftOrLast
+            | Action::FocusColumnOrMonitorLeft
+            | Action::FocusWindowUpOrColumnLeft => Action::MruAdvance {
+                direction: MruDirection::Backward,
+                scope: None,
+                filter: None,
+            },
+            Action::FocusColumnFirst => Action::MruFirst,
+            Action::FocusColumnLast => Action::MruLast,
+            Action::CloseWindow => Action::MruCloseCurrentWindow,
+            x @ Action::Screenshot(_, _) => x.clone(),
+            _ => continue,
+        };
+
+        binds.entry(bind.key.trigger).or_default().push(Bind {
+            actions: vec![action],
+            ..bind.clone()
+        });
+    }
+```
+
+- [ ] **Step 9: Update `src/ui/hotkey_overlay.rs`**
+
+In `format_bind` (line 161), a bind matches the wanted action only if it holds exactly that one action:
+
+```rust
+    for bind in binds {
+        // Multi-action binds are not shown in the hotkey overlay.
+        if bind.actions.as_slice() != std::slice::from_ref(action) {
+            continue;
+        }
+```
+
+In `collect_actions` (lines 205-250), the five `bind.action` reads become slice patterns:
+
+```rust
+    if binds
+        .iter()
+        .any(|bind| bind.actions.as_slice() == [Action::Quit(false)])
+    {
+        actions.push(&Action::Quit(false));
+    } else if binds
+        .iter()
+        .any(|bind| bind.actions.as_slice() == [Action::Quit(true)])
+    {
+        actions.push(&Action::Quit(true));
+    } else {
+        actions.push(&Action::Quit(false));
+    }
+```
+
+and, for the two workspace-down/-up blocks:
+
+```rust
+    // Prefer move-column-to-workspace-down, but fall back to move-window-to-workspace-down.
+    if let Some(bind) = binds
+        .iter()
+        .find(|bind| matches!(bind.actions.as_slice(), [Action::MoveColumnToWorkspaceDown(_)]))
+    {
+        actions.push(&bind.actions[0]);
+    } else if binds
+        .iter()
+        .any(|bind| matches!(bind.actions.as_slice(), [Action::MoveWindowToWorkspaceDown(_)]))
+    {
+        actions.push(&Action::MoveWindowToWorkspaceDown(true));
+    } else {
+        actions.push(&Action::MoveColumnToWorkspaceDown(true));
+    }
+
+    // Same for -up.
+    if let Some(bind) = binds
+        .iter()
+        .find(|bind| matches!(bind.actions.as_slice(), [Action::MoveColumnToWorkspaceUp(_)]))
+    {
+        actions.push(&bind.actions[0]);
+    } else if binds
+        .iter()
+        .any(|bind| matches!(bind.actions.as_slice(), [Action::MoveWindowToWorkspaceUp(_)]))
+    {
+        actions.push(&Action::MoveWindowToWorkspaceUp(true));
+    } else {
+        actions.push(&Action::MoveColumnToWorkspaceUp(true));
+    }
+```
+
+- [ ] **Step 10: Build and fix any remaining compile errors**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo build 2>&1 | tail -40'
+```
+
+Expected on the first run: errors naming any `action:` field or `bind.action` read still left over. Fix each by the same rules — a construction becomes `actions: vec![X]`, a single read becomes a slice pattern or `bind.actions[0]`. Repeat until the build is clean.
+
+- [ ] **Step 11: Update the two existing tests that read `bind.action`**
+
+`niri-config/src/binds.rs:1111` inside `parse_window_shader_actions`:
+
+```rust
+        let actions: Vec<_> = config
+            .binds
+            .0
+            .iter()
+            .map(|b| b.actions[0].clone())
+            .collect();
+```
+
+`niri-config/src/lib.rs:714`:
+
+```rust
+            .map(|bind| bind.actions[0].clone())
+```
+
+- [ ] **Step 12: Update the 18 inline snapshot blocks and run the tests**
+
+`Bind`'s debug output changes from `action: X,` to `actions: [\n    X,\n],` with the surrounding indentation. Hand-edit the 18 blocks in `niri-config/src/lib.rs`. Do **not** run `cargo insta accept` — it has hung on this repo.
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test 2>&1 | tail -30'
+```
+
+Expected: the same pass count recorded in Step 1. If a snapshot test fails, read the diff it prints (or `niri-config/src/.lib.rs.pending-snap`) and hand-apply it.
+
+- [ ] **Step 13: Format, lint, commit**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo fmt --all && cargo clippy --all-targets 2>&1 | tail -20'
+git add -A niri-config/src src/input/mod.rs src/ui/mru.rs src/ui/hotkey_overlay.rs
+git commit -m "config: hold a list of actions per bind
+
+Pure refactor: Bind.action becomes Bind.actions: Vec<Action>. The parser
+still rejects more than one action per bind, so behaviour is unchanged.
+Folds over the new list are chosen so they are no-ops for a one-element
+list: 'any' for the cooldown lock pre-check, 'all' for screenshot-UI
+eligibility, exactly-one for the hotkey overlay and MRU binds."
+```
+
+---
+
+### Task 2: Parse and validate multiple actions per bind
+
+Turns the feature on for the config half.
+
+**Files:**
+- Modify: `niri-config/src/binds.rs:925-980` (`Bind::decode_node`)
+- Test: `niri-config/src/binds.rs` (`mod tests` at line ~1096)
+- Modify: `docs/wiki/Configuration:-Key-Bindings.md`
+
+**Interfaces:**
+- Consumes: `Bind { actions: Vec<Action>, .. }` from Task 1
+- Produces: a bind whose `actions` holds every child node in source order
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests` in `niri-config/src/binds.rs`:
+
+```rust
+    #[test]
+    fn parse_multiple_actions_in_order() {
+        let config = crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+G { focus-column-right; consume-or-expel-window-left; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.binds.0.len(), 1);
+        assert_eq!(
+            config.binds.0[0].actions,
+            [Action::FocusColumnRight, Action::ConsumeOrExpelWindowLeft],
+        );
+    }
+
+    #[test]
+    fn parse_bind_with_no_actions_still_errors() {
+        assert!(crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+G { }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn parse_bad_action_among_several_keeps_the_others() {
+        // The bad action in the middle must not swallow the third one's decoding.
+        assert!(crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+G { focus-column-right; not-a-real-action; close-window; }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn allow_when_locked_rejected_on_mixed_bind() {
+        // Every action must be spawn/spawn-sh, otherwise allow-when-locked would let a
+        // non-spawn action run from the lock screen.
+        assert!(crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+X allow-when-locked=true { spawn "foo"; quit; }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn allow_when_locked_accepted_on_all_spawn_bind() {
+        let config = crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+X allow-when-locked=true { spawn "foo"; spawn-sh "bar"; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert!(config.binds.0[0].allow_when_locked);
+        assert_eq!(config.binds.0[0].actions.len(), 2);
+    }
+
+    #[test]
+    fn toggle_inhibit_anywhere_in_list_forces_allow_inhibiting_false() {
+        let config = crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+Escape { close-window; toggle-keyboard-shortcuts-inhibit; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert!(!config.binds.0[0].allow_inhibiting);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test -p niri-config binds 2>&1 | tail -30'
+```
+
+Expected: `parse_multiple_actions_in_order`, `allow_when_locked_accepted_on_all_spawn_bind` and `toggle_inhibit_anywhere_in_list_forces_allow_inhibiting_false` FAIL (the parser still emits "only one action is allowed per keybind"). `parse_bind_with_no_actions_still_errors` and `parse_bad_action_among_several_keeps_the_others` should already PASS.
+
+- [ ] **Step 3: Rewrite the decoder's child loop**
+
+In `niri-config/src/binds.rs`, replace everything from `let mut children = node.children();` (line ~925) through the end of `decode_node` with:
+
+```rust
+        // If the actions are invalid but the key is fine, we still want to return something.
+        // That way, the parent can handle the existence of duplicate keybinds,
+        // even if their contents are not valid.
+        let dummy = Self {
+            key,
+            actions: Vec::new(),
+            repeat: true,
+            cooldown: None,
+            allow_when_locked: false,
+            allow_inhibiting: true,
+            hotkey_overlay_title: None,
+        };
+
+        let mut actions = Vec::new();
+        let mut had_error = false;
+        for child in node.children() {
+            match Action::decode_node(child, ctx) {
+                // Emit the error and keep going, so that a typo in one action still surfaces
+                // the errors in the actions after it.
+                Err(e) => {
+                    ctx.emit_error(e);
+                    had_error = true;
+                }
+                Ok(action) => actions.push(action),
+            }
+        }
+
+        if actions.is_empty() {
+            if !had_error {
+                ctx.emit_error(DecodeError::missing(
+                    node,
+                    "expected an action for this keybind",
+                ));
+            }
+            return Ok(dummy);
+        }
+
+        // allow-when-locked must hold for *every* action: handle_bind passes one flag into
+        // every do_action call, so a mixed bind would let a non-spawn action run from the
+        // lock screen.
+        if !actions
+            .iter()
+            .all(|a| matches!(a, Action::Spawn(_) | Action::SpawnSh(_)))
+        {
+            if let Some(node) = allow_when_locked_node {
+                ctx.emit_error(DecodeError::unexpected(
+                    node,
+                    "property",
+                    "allow-when-locked can only be set on binds where every action is spawn",
+                ));
+            }
+        }
+
+        // The toggle-inhibit action must always be uninhibitable. Otherwise, it would be
+        // impossible to trigger it.
+        if actions
+            .iter()
+            .any(|a| matches!(a, Action::ToggleKeyboardShortcutsInhibit))
+        {
+            allow_inhibiting = false;
+        }
+
+        Ok(Self {
+            key,
+            actions,
+            repeat,
+            cooldown,
+            allow_when_locked,
+            allow_inhibiting,
+            hotkey_overlay_title,
+        })
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test -p niri-config 2>&1 | tail -30'
+```
+
+Expected: all six new tests PASS and the rest of `niri-config` is still green.
+
+- [ ] **Step 5: Run the whole suite**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test 2>&1 | tail -30'
+```
+
+Expected: PASS. The old `"only one action is allowed per keybind"` string is gone; if a test asserted on it, update that assertion.
+
+- [ ] **Step 6: Document the config half**
+
+Add to `docs/wiki/Configuration:-Key-Bindings.md`, as a new `### Multiple Actions` section placed after `### Custom Hotkey Overlay Titles` (line 133) and before `### Actions` (line 172):
+
+````markdown
+### Multiple Actions
+
+A bind can list several actions. They run in order, with nothing else running in
+between them.
+
+```kdl
+binds {
+    Mod+G { focus-column-right; consume-or-expel-window-left; }
+}
+```
+
+Two limitations apply to multi-action binds:
+
+- They never appear in the hotkey overlay, and `hotkey-overlay-title` has no effect on
+  them.
+- `allow-when-locked=true` is accepted only when *every* action in the bind is `spawn`
+  or `spawn-sh`. Otherwise the flag would let a non-spawn action run from the lock
+  screen.
+
+If an action cannot run — for example a non-spawn action on a locked screen — it is
+skipped and the remaining actions still run.
+````
+
+- [ ] **Step 7: Format, lint, commit**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo fmt --all && cargo clippy --all-targets 2>&1 | tail -20'
+git add niri-config/src/binds.rs docs/wiki/Configuration:-Key-Bindings.md
+git commit -m "config: allow several actions in one bind
+
+Mod+G { focus-column-right; consume-or-expel-window-left; } now parses,
+running both actions in source order. A malformed action is reported and
+skipped so later actions still get decoded. allow-when-locked now requires
+every action to be spawn/spawn-sh, and toggle-keyboard-shortcuts-inhibit
+anywhere in the list forces allow-inhibiting off."
+```
+
+---
+
+### Task 3: `Request::Actions` IPC batch
+
+**Files:**
+- Modify: `niri-ipc/src/lib.rs:91` (`Request` enum)
+- Modify: `src/ipc/server.rs:393-411` (add an `Actions` arm next to the existing `Action` arm)
+- Test: `niri-ipc/src/lib.rs` (the existing `mod tests` at line 2188)
+
+**Interfaces:**
+- Consumes: `State::do_actions(Vec<niri_config::Action>, bool)` from Task 1
+- Produces: `niri_ipc::Request::Actions(Vec<Action>)`, answered with `Response::Handled`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `mod tests` in `niri-ipc/src/lib.rs` (line 2188). `serde_json` is already
+a normal dependency of the crate, and `Request` already derives `Debug`.
+
+```rust
+    #[test]
+    fn actions_request_round_trips() {
+        let request = Request::Actions(vec![
+            Action::FocusColumnRight {},
+            Action::CloseWindow { id: None },
+        ]);
+
+        let json = serde_json::to_string(&request).unwrap();
+        let back: Request = serde_json::from_str(&json).unwrap();
+
+        let Request::Actions(actions) = back else {
+            panic!("expected Actions, got {back:?}");
+        };
+        assert_eq!(actions.len(), 2);
+        assert!(matches!(actions[0], Action::FocusColumnRight {}));
+        assert!(matches!(actions[1], Action::CloseWindow { id: None }));
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test -p niri-ipc actions_request_round_trips 2>&1 | tail -20'
+```
+
+Expected: FAIL — `no variant named 'Actions' found for enum 'Request'`.
+
+- [ ] **Step 3: Add the request variant**
+
+`niri-ipc/src/lib.rs`, directly after the existing `Action(Action),` at line 91:
+
+```rust
+    /// Perform several actions as one atomic sequence.
+    ///
+    /// All actions are validated before any of them runs; if any is invalid, none run. The
+    /// actions then run in order with nothing else running in between, which is what
+    /// distinguishes this from several [`Request::Action`] calls.
+    Actions(Vec<Action>),
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test -p niri-ipc actions_request_round_trips 2>&1 | tail -20'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Handle the request in the server**
+
+`src/ipc/server.rs`, add this arm immediately after the existing `Request::Action(action) => { .. }` arm (which ends at line 411):
+
+```rust
+        Request::Actions(actions) => {
+            // Validate everything up front: an invalid action anywhere rejects the whole
+            // batch, so a partial sequence never runs.
+            for (idx, action) in actions.iter().enumerate() {
+                validate_action(action).map_err(|err| format!("action {}: {err}", idx + 1))?;
+            }
+
+            let (tx, rx) = async_channel::bounded(1);
+
+            let actions: Vec<niri_config::Action> =
+                actions.into_iter().map(niri_config::Action::from).collect();
+            // One idle callback for the whole batch. This is the point of the request:
+            // nothing can interleave between the actions. Queuing one callback per action
+            // would not give that guarantee.
+            ctx.event_loop.insert_idle(move |state| {
+                // Make sure some logic like workspace clean-up has a chance to run before
+                // doing actions.
+                state.niri.advance_animations();
+                state.do_actions(actions, false);
+                let _ = tx.send_blocking(());
+            });
+
+            // Wait until the actions have been processed before returning, for the same
+            // reason as the single-action request.
+            let _ = rx.recv().await;
+            Response::Handled
+        }
+```
+
+- [ ] **Step 6: Build and run the suite**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo build 2>&1 | tail -20 && cargo test 2>&1 | tail -20'
+```
+
+Expected: build clean, all tests PASS. If the compiler reports a non-exhaustive match anywhere else over `Request`, add an `Actions` arm there too.
+
+- [ ] **Step 7: Format, lint, commit**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo fmt --all && cargo clippy --all-targets 2>&1 | tail -20'
+git add niri-ipc/src/lib.rs src/ipc/server.rs
+git commit -m "ipc: add Request::Actions for atomic action batches
+
+Every action is validated before any runs, and the whole batch runs inside a
+single idle callback so nothing interleaves between the actions. That is the
+property chaining 'niri msg action' calls cannot provide."
+```
+
+---
+
+### Task 4: `niri msg actions` CLI
+
+**Files:**
+- Modify: `Cargo.toml` (add the `shlex` dependency)
+- Modify: `src/cli.rs:85-88` (add the `Actions` variant, and an `ActionParser` helper)
+- Modify: `src/ipc/client.rs:19-30` (path fixup), `:39` (request mapping), `:321` (response check)
+- Test: `src/cli.rs` (`mod tests`)
+- Modify: `docs/wiki/Configuration:-Key-Bindings.md`
+
+**Interfaces:**
+- Consumes: `niri_ipc::Request::Actions(Vec<Action>)` from Task 3
+- Produces: `Msg::Actions { actions: Vec<String> }` in `src/cli.rs`
+- Produces: `fn parse_action_words(words: Vec<String>) -> anyhow::Result<Action>` in `src/cli.rs`
+- Produces: `fn parse_actions(args: &[String], stdin: &str) -> anyhow::Result<Vec<Action>>` in `src/cli.rs`
+
+- [ ] **Step 1: Add the dependency**
+
+In the root `Cargo.toml`, under `[dependencies]` (alongside `clap` at line 64):
+
+```toml
+shlex = "1.3"
+```
+
+`shlex 1.3.0` is already in `Cargo.lock` as a transitive dependency, so this pulls nothing new.
+
+- [ ] **Step 2: Write the failing tests**
+
+`src/cli.rs` has no test module yet (the file is 139 lines). Create one at the end:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_and_stdin_produce_the_same_actions() {
+        let args = vec![
+            String::from("toggle-workspace-visibility stash"),
+            String::from("focus-workspace stash"),
+        ];
+        let from_args = parse_actions(&args, "").unwrap();
+
+        let stdin = "toggle-workspace-visibility stash\nfocus-workspace stash\n";
+        let from_stdin = parse_actions(&[], stdin).unwrap();
+
+        assert_eq!(from_args.len(), 2);
+        assert_eq!(format!("{from_args:?}"), format!("{from_stdin:?}"));
+    }
+
+    #[test]
+    fn blank_stdin_lines_are_skipped() {
+        let stdin = "focus-column-right\n\n   \nclose-window\n";
+        let actions = parse_actions(&[], stdin).unwrap();
+        assert_eq!(actions.len(), 2);
+    }
+
+    #[test]
+    fn quoted_arguments_survive_lexing() {
+        let args = vec![String::from(r#"spawn sh -c "echo hello world""#)];
+        let actions = parse_actions(&args, "").unwrap();
+        let Action::Spawn { command } = &actions[0] else {
+            panic!("expected Spawn, got {:?}", actions[0]);
+        };
+        assert_eq!(command, &["sh", "-c", "echo hello world"]);
+    }
+
+    #[test]
+    fn a_bad_action_names_its_position() {
+        let args = vec![
+            String::from("focus-column-right"),
+            String::from("not-a-real-action"),
+        ];
+        let err = parse_actions(&args, "").unwrap_err().to_string();
+        assert!(err.contains('2'), "error should name argument 2: {err}");
+    }
+
+    #[test]
+    fn no_args_and_no_stdin_is_an_error() {
+        assert!(parse_actions(&[], "").is_err());
+    }
+}
+```
+
+- [ ] **Step 3: Run them to verify they fail**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test --bin niri parse_actions 2>&1 | tail -20'
+```
+
+Expected: FAIL to compile — `cannot find function 'parse_actions'`.
+
+- [ ] **Step 4: Add the CLI variant and the parsing functions**
+
+In `src/cli.rs`, add the subcommand directly after the existing `Action { .. }` variant at line 85-88:
+
+```rust
+    /// Perform several actions as one atomic sequence.
+    ///
+    /// Each argument is one action, for example:
+    ///
+    ///   niri msg actions "toggle-workspace-visibility stash" "focus-workspace stash"
+    ///
+    /// With no arguments, actions are read from stdin, one per line.
+    Actions {
+        /// One action per argument. Reads actions from stdin, one per line, if empty.
+        #[arg()]
+        actions: Vec<String>,
+    },
+```
+
+Then, at the end of the file (before any `mod tests`):
+
+```rust
+/// Wrapper that lets a single `Action` be parsed from a bare word list.
+///
+/// `Action` is a clap `Subcommand`, so it needs a `Parser` around it, and
+/// `no_binary_name` so that the first word is read as the subcommand rather than as
+/// argv[0].
+#[derive(clap::Parser)]
+#[command(name = "", no_binary_name = true)]
+struct ActionParser {
+    #[command(subcommand)]
+    action: Action,
+}
+
+/// Parses one action from an already-lexed word list.
+pub fn parse_action_words(words: Vec<String>) -> anyhow::Result<Action> {
+    use clap::Parser as _;
+
+    Ok(ActionParser::try_parse_from(words)?.action)
+}
+
+/// Parses a batch of actions from CLI arguments, falling back to stdin when there are none.
+///
+/// Argument form and stdin form must produce identical output.
+pub fn parse_actions(args: &[String], stdin: &str) -> anyhow::Result<Vec<Action>> {
+    use anyhow::{anyhow, Context as _};
+
+    let sources: Vec<(String, String)> = if args.is_empty() {
+        stdin
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| !line.trim().is_empty())
+            .map(|(idx, line)| (format!("stdin line {}", idx + 1), line.to_owned()))
+            .collect()
+    } else {
+        args.iter()
+            .enumerate()
+            .map(|(idx, arg)| (format!("argument {}", idx + 1), arg.clone()))
+            .collect()
+    };
+
+    if sources.is_empty() {
+        return Err(anyhow!(
+            "no actions given; pass one action per argument, or one per line on stdin"
+        ));
+    }
+
+    let mut actions = Vec::with_capacity(sources.len());
+    for (label, text) in sources {
+        let words = shlex::split(&text)
+            .ok_or_else(|| anyhow!("{label}: unbalanced quotes in {text:?}"))?;
+        if words.is_empty() {
+            return Err(anyhow!("{label}: empty action"));
+        }
+        actions.push(parse_action_words(words).with_context(|| format!("{label}"))?);
+    }
+
+    Ok(actions)
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo test --bin niri 2>&1 | tail -20'
+```
+
+Expected: all five new tests PASS.
+
+- [ ] **Step 6: Wire the variant through the client**
+
+`src/ipc/client.rs`. First, in `handle_msg`, read stdin and build the request. Add this immediately after the existing path-fixup block that ends at line 30:
+
+```rust
+    // Resolve `niri msg actions` before the request match, since it may read stdin.
+    let batched_actions = if let Msg::Actions { actions } = &msg {
+        use std::io::Read as _;
+
+        let mut stdin = String::new();
+        if actions.is_empty() {
+            std::io::stdin()
+                .read_to_string(&mut stdin)
+                .context("error reading actions from stdin")?;
+        }
+
+        let mut parsed = crate::cli::parse_actions(actions, &stdin)?;
+        // For actions taking paths, prepend the niri CLI's working directory.
+        for action in &mut parsed {
+            if let Action::Screenshot { path, .. }
+            | Action::ScreenshotScreen { path, .. }
+            | Action::ScreenshotWindow { path, .. } = action
+            {
+                if let Some(path) = path {
+                    ensure_absolute_path(path).context("error making the path absolute")?;
+                }
+            }
+        }
+        Some(parsed)
+    } else {
+        None
+    };
+```
+
+Then add the request mapping next to `Msg::Action` at line 39:
+
+```rust
+        Msg::Actions { .. } => Request::Actions(batched_actions.clone().unwrap()),
+```
+
+And the response check next to `Msg::Action { .. }` at line 321:
+
+```rust
+        Msg::Actions { .. } => {
+            let Response::Handled = response else {
+                bail!("unexpected response: expected Handled, got {response:?}");
+            };
+        }
+```
+
+- [ ] **Step 7: Build and run the whole suite**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo build 2>&1 | tail -20 && cargo test 2>&1 | tail -20'
+```
+
+Expected: build clean, all tests PASS. If the compiler reports a non-exhaustive match over `Msg`, add an `Actions` arm there.
+
+- [ ] **Step 8: Check the help text renders**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c './target/debug/niri msg actions --help'
+```
+
+Expected: the help shows the `actions` subcommand with the multi-line example from Step 4.
+
+- [ ] **Step 9: Document the IPC half**
+
+Append to the `### Multiple Actions` section added in Task 2, in `docs/wiki/Configuration:-Key-Bindings.md`:
+
+````markdown
+The same sequencing is available over IPC. `niri msg action` runs one action per
+invocation, so chaining two with `&&` leaves a window in which other events run;
+`niri msg actions` sends the whole list as one batch that runs with nothing in between.
+
+```sh
+# one action per argument
+niri msg actions "toggle-workspace-visibility stash" "focus-workspace stash"
+
+# or one per line on stdin
+printf 'focus-column-right\nconsume-or-expel-window-left\n' | niri msg actions
+```
+
+If any action in the batch is invalid, none of them run.
+````
+
+- [ ] **Step 10: Format, lint, commit**
+
+```bash
+cd /home/barrulus/dev/biri
+direnv exec . bash -c 'cargo fmt --all && cargo clippy --all-targets 2>&1 | tail -20'
+git add Cargo.toml Cargo.lock src/cli.rs src/ipc/client.rs docs/wiki/Configuration:-Key-Bindings.md
+git commit -m "cli: add 'niri msg actions' for atomic action batches
+
+One action per argument, shell-lexed and parsed as a subcommand; with no
+arguments, one action per stdin line. Both forms produce the same batch. clap
+cannot chain subcommands, which is why this is a separate command rather than
+an extension of 'niri msg action'."
+```
+
+---
+
+## Manual verification
+
+Automated tests cannot cover ordering inside a live compositor. After Task 4, run the compositor and confirm:
+
+1. Add to your config and reload:
+   ```kdl
+   binds {
+       Mod+G { focus-column-right; consume-or-expel-window-left; }
+   }
+   ```
+   Press `Mod+G` with at least two columns open. Both actions must take effect, in that order, in one frame.
+2. `niri msg actions "toggle-workspace-visibility stash" "focus-workspace stash"` must switch to the now-visible workspace with no intermediate flash — the chain from biri #24 that previously needed `spawn-sh` with `&&`.
+3. `niri msg actions "focus-column-right" "not-a-real-action"` must print an error naming argument 2 and must **not** move focus.
+4. Open the hotkey overlay (`Mod+Shift+Escape` by default). The multi-action `Mod+G` bind must not appear.
+5. Lock the screen. A bind such as `Mod+X allow-when-locked=true { spawn "notify-send hi"; spawn-sh "true"; }` still works; the config must refuse to load if `quit` is added to that bind.

--- a/docs/superpowers/specs/2026-09-06-multi-action-binds-design.md
+++ b/docs/superpowers/specs/2026-09-06-multi-action-binds-design.md
@@ -1,0 +1,215 @@
+# Multi-action binds
+
+Design for biri issue #32 / upstream niri#914.
+
+## Goal
+
+Two halves, both in scope:
+
+1. **Config.** One bind runs several actions in order:
+   `Mod+G { focus-column-right; consume-or-expel-window-left; }`
+2. **IPC.** Several actions sent as one batch, so they run as one atomic sequence with no
+   delay between them. `niri msg action` cannot do this today; chaining two invocations
+   with `&&` leaves a window in which other events run.
+
+The fork keeps growing one-off `focus=true` flags (hidden workspaces, PR #26) to dodge
+chaining. This feature removes the reason for those.
+
+## Intent to upstream
+
+The internal shape follows what YaLTeR and bbb651 already settled on upstream: `Bind` holds
+a `Vec<Action>`. A `Action::Sequence(Vec<Action>)` variant would have been a far smaller
+diff for biri, but it diverges from the agreed upstream shape and would have to be reshaped
+later. The larger mechanical diff is accepted deliberately.
+
+Decisions already made upstream and adopted here without re-litigating them:
+
+- The hotkey overlay ignores multi-action binds.
+- The CLI gets a separate `Actions` variant, because clap cannot chain subcommands.
+- A failed `allow-when-locked` check skips just that action; the rest still run.
+- A general `or` combinator is rejected. Existing `*-or-*` actions are left alone.
+
+## Config shape and parsing
+
+`niri-config/src/binds.rs`
+
+```rust
+pub struct Bind {
+    pub key: Key,
+    pub actions: Vec<Action>,   // was: action: Action
+    pub repeat: bool,
+    pub cooldown: Option<Duration>,
+    pub allow_when_locked: bool,
+    pub allow_inhibiting: bool,
+    pub hotkey_overlay_title: Option<Option<String>>,
+}
+```
+
+`Bind::decode_node` drops the "only one action is allowed per keybind" error and decodes
+every child node into the list, preserving source order.
+
+- A child that fails to decode emits its error and is **skipped**; decoding continues. A
+  typo in the second action still surfaces the third action's errors in the same pass.
+- Zero children keeps the existing "expected an action for this keybind" error and returns
+  the dummy bind with `actions: Vec::new()`. The dummy exists only so `Binds::decode_node`
+  can still detect duplicate keys; an empty list is inert everywhere downstream.
+
+Nesting is unrepresentable by construction. The list is flat and there is no `Sequence`
+variant to recurse into.
+
+### Validation folds
+
+Two existing per-action validations become folds over the list. The choice of fold is
+load-bearing in both cases.
+
+**`allow-when-locked` requires *every* action to be `spawn`/`spawn-sh`.** It must be *all*,
+not *any*. `handle_bind` passes a single `bind.allow_when_locked` flag into every
+`do_action` call, so accepting a mixed bind would let
+
+```kdl
+Mod+X allow-when-locked=true { spawn "foo"; quit; }
+```
+
+run `quit` from the lock screen. That is a lock-screen bypass. *All* is the only safe fold.
+
+**`ToggleKeyboardShortcutsInhibit` forces `allow_inhibiting = false` if *any* action is that
+variant.** Otherwise the bind that un-inhibits shortcuts could itself be inhibited, leaving
+no way to trigger it.
+
+## Input dispatch
+
+`src/input/mod.rs`
+
+`handle_bind` loops over the list:
+
+```rust
+for action in bind.actions {
+    self.do_action(action, bind.allow_when_locked);
+}
+```
+
+`do_action` keeps its `Action` signature and its own lock check, which is what gives the
+upstream-agreed semantics: a locked-out action is skipped, the rest still run. There is no
+stop-on-failure mode, because nothing in `do_action` returns an error to stop on.
+
+Two more folds:
+
+- **Cooldown pre-check** (currently `input/mod.rs:692`) becomes *any*: run the bind if
+  `bind.allow_when_locked || bind.actions.iter().any(allowed_when_locked)`. Otherwise skip
+  the bind **without** burning its cooldown timer, matching today's behaviour.
+- **`allowed_during_screenshot`** gains a `bind_allowed_during_screenshot(&bind)` helper
+  folding with *all*, replacing the ~10 `allowed_during_screenshot(&bind.action)` call
+  sites. The screenshot UI must never be handed a bind it can only half-run. An empty list
+  is vacuously true, which is harmless because nothing runs.
+
+Then the mechanical part: 45 `Bind { action: X, .. }` constructions — almost all synthetic
+binds for the screenshot UI, overview and gestures — become `actions: vec![X]`.
+
+## IPC
+
+`niri-ipc/src/lib.rs`, `src/ipc/server.rs`
+
+New request variant; the existing single-action one is untouched for compatibility.
+
+```rust
+pub enum Request {
+    Action(Action),           // unchanged
+    Actions(Vec<Action>),     // new
+    ...
+}
+```
+
+Server handling:
+
+1. Validate **all** actions up front with the existing `validate_action`, per element.
+   An error is prefixed with the 1-based index so the caller knows which action failed.
+   Nothing runs if any action is invalid.
+2. Queue **one** idle callback that calls `advance_animations()` once and then runs every
+   action in order.
+3. Reply `Response::Handled`.
+
+Step 2 is the point of the feature. One callback means nothing can interleave between the
+actions, which is the "one atomic sequence with no delay in-between" property the upstream
+maintainer named as the priority. Queuing one callback per action would not provide it.
+
+No per-action results are returned. `do_action` returns `()`, and the only fallible step is
+pre-flight validation, so there is nothing per-action to report.
+
+## CLI
+
+`src/cli.rs`, `src/ipc/client.rs`
+
+```rust
+/// Perform several actions as one atomic sequence.
+Actions {
+    /// One action per argument. Reads actions from stdin, one per line, if empty.
+    #[arg()]
+    actions: Vec<String>,
+},
+```
+
+Each argument is shell-lexed with `shlex` (already in `Cargo.lock` transitively; becomes a
+direct dependency) and parsed with `Action::try_parse_from`. With no arguments, actions are
+read from stdin one per line, skipping blank lines. Parse errors name the offending
+argument index or stdin line number.
+
+```sh
+# one-liner, usable directly from a KDL bind
+niri msg actions "toggle-workspace-visibility stash" "focus-workspace stash"
+
+# scripted
+printf 'focus-column-right\nconsume-or-expel-window-left\n' | niri msg actions
+```
+
+Argument form and stdin form must produce an identical `Vec<Action>`.
+
+## Hotkey overlay
+
+`src/ui/hotkey_overlay.rs`
+
+Multi-action binds are skipped. `format_bind` and `collect_actions` match only binds whose
+`actions` slice holds exactly one element, so a multi-action bind never matches an entry in
+the overlay's fixed list of interesting actions and simply does not appear. No new
+rendering, no new layout.
+
+## Out of scope
+
+- Switch binds (`SwitchAction`) and gesture binds. They do not carry an `Action`.
+- Any `or` combinator or conditional action. Rejected upstream.
+- Converting existing `*-or-*` actions into conditions.
+- Nested sequences. Unrepresentable by construction, as above.
+
+## Testing
+
+`niri-config/src/binds.rs`:
+
+- Two actions parse, in source order.
+- Zero actions still errors.
+- One malformed action among three reports its error and keeps the other two.
+- `allow-when-locked` is rejected on a mixed bind, accepted on an all-spawn bind.
+- `ToggleKeyboardShortcutsInhibit` anywhere in the list forces `allow_inhibiting = false`.
+
+IPC and CLI:
+
+- `Request::Actions` round-trips through serde.
+- Argument lexing and stdin lexing produce the same `Vec<Action>`.
+- An invalid action anywhere in the batch rejects the whole batch, and the error names its
+  index.
+
+Documentation: `docs/wiki/Configuration:-Key-Bindings.md` gains a multi-action section.
+
+### Known risk
+
+`Bind`'s debug output changes from `action: X` to `actions: [X]`, and 18 of those lines sit
+inside the very large inline snapshots in `niri-config/src/lib.rs`. `cargo insta accept` has
+hung on this repo before, so those 18 lines are hand-edited, with `.lib.rs.pending-snap`
+inspection as the fallback if the diff turns out larger than expected.
+
+## Open questions resolved
+
+The issue listed three. All are settled above:
+
+- **Stop-on-failure or continue** — continue, per action, matching the upstream decision.
+  There is no error channel to stop on anyway.
+- **Per-action results over IPC** — none. Validation is pre-flight; execution is infallible.
+- **Whether `*-or-*` actions become conditions** — no, out of scope.

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -169,6 +169,28 @@ binds {
 
 ![Custom markup example.](https://github.com/user-attachments/assets/2a2ba914-bfa7-4dfa-bb5e-49839034765d)
 
+### Multiple Actions
+
+A bind can list several actions. They run in order, with nothing else running in
+between them.
+
+```kdl
+binds {
+    Mod+G { focus-column-right; consume-or-expel-window-left; }
+}
+```
+
+Two limitations apply to multi-action binds:
+
+- They never appear in the hotkey overlay, and `hotkey-overlay-title` has no effect on
+  them.
+- `allow-when-locked=true` is accepted only when *every* action in the bind is `spawn`
+  or `spawn-sh`. Otherwise the flag would let a non-spawn action run from the lock
+  screen.
+
+If an action cannot run — for example a non-spawn action on a locked screen — it is
+skipped and the remaining actions still run.
+
 ### Actions
 
 Every action that you can bind is also available for programmatic invocation via `niri msg action`.

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -191,6 +191,20 @@ Two limitations apply to multi-action binds:
 If an action cannot run — for example a non-spawn action on a locked screen — it is
 skipped and the remaining actions still run.
 
+The same sequencing is available over IPC. `niri msg action` runs one action per
+invocation, so chaining two with `&&` leaves a window in which other events run;
+`niri msg actions` sends the whole list as one batch that runs with nothing in between.
+
+```sh
+# one action per argument
+niri msg actions "toggle-workspace-visibility stash" "focus-workspace stash"
+
+# or one per line on stdin
+printf 'focus-column-right\nconsume-or-expel-window-left\n' | niri msg actions
+```
+
+If any action in the batch is invalid, none of them run.
+
 ### Actions
 
 Every action that you can bind is also available for programmatic invocation via `niri msg action`.

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -203,6 +203,14 @@ niri msg actions "toggle-workspace-visibility stash" "focus-workspace stash"
 printf 'focus-column-right\nconsume-or-expel-window-left\n' | niri msg actions
 ```
 
+`spawn`'s command is a trailing argument list, so on the command line it needs a `--`
+before the program and its arguments, or the shell parser will try to consume them as
+`spawn`'s own flags:
+
+```sh
+niri msg actions "spawn -- notify-send hi"
+```
+
 If any action in the batch is invalid, none of them run.
 
 ### Actions

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -922,9 +922,7 @@ where
             }
         }
 
-        let mut children = node.children();
-
-        // If the action is invalid but the key is fine, we still want to return something.
+        // If the actions are invalid but the key is fine, we still want to return something.
         // That way, the parent can handle the existence of duplicate keybinds,
         // even if their contents are not valid.
         let dummy = Self {
@@ -937,54 +935,64 @@ where
             hotkey_overlay_title: None,
         };
 
-        if let Some(child) = children.next() {
-            for unwanted_child in children {
-                ctx.emit_error(DecodeError::unexpected(
-                    unwanted_child,
-                    "node",
-                    "only one action is allowed per keybind",
-                ));
-            }
+        let mut actions = Vec::new();
+        let mut had_error = false;
+        for child in node.children() {
             match Action::decode_node(child, ctx) {
-                Ok(action) => {
-                    if !matches!(action, Action::Spawn(_) | Action::SpawnSh(_)) {
-                        if let Some(node) = allow_when_locked_node {
-                            ctx.emit_error(DecodeError::unexpected(
-                                node,
-                                "property",
-                                "allow-when-locked can only be set on spawn binds",
-                            ));
-                        }
-                    }
-
-                    // The toggle-inhibit action must always be uninhibitable.
-                    // Otherwise, it would be impossible to trigger it.
-                    if matches!(action, Action::ToggleKeyboardShortcutsInhibit) {
-                        allow_inhibiting = false;
-                    }
-
-                    Ok(Self {
-                        key,
-                        actions: vec![action],
-                        repeat,
-                        cooldown,
-                        allow_when_locked,
-                        allow_inhibiting,
-                        hotkey_overlay_title,
-                    })
-                }
+                // Emit the error and keep going, so that a typo in one action still surfaces
+                // the errors in the actions after it.
                 Err(e) => {
                     ctx.emit_error(e);
-                    Ok(dummy)
+                    had_error = true;
                 }
+                Ok(action) => actions.push(action),
             }
-        } else {
-            ctx.emit_error(DecodeError::missing(
-                node,
-                "expected an action for this keybind",
-            ));
-            Ok(dummy)
         }
+
+        if actions.is_empty() {
+            if !had_error {
+                ctx.emit_error(DecodeError::missing(
+                    node,
+                    "expected an action for this keybind",
+                ));
+            }
+            return Ok(dummy);
+        }
+
+        // allow-when-locked must hold for *every* action: handle_bind passes one flag into
+        // every do_action call, so a mixed bind would let a non-spawn action run from the
+        // lock screen.
+        if !actions
+            .iter()
+            .all(|a| matches!(a, Action::Spawn(_) | Action::SpawnSh(_)))
+        {
+            if let Some(node) = allow_when_locked_node {
+                ctx.emit_error(DecodeError::unexpected(
+                    node,
+                    "property",
+                    "allow-when-locked can only be set on binds where every action is spawn",
+                ));
+            }
+        }
+
+        // The toggle-inhibit action must always be uninhibitable. Otherwise, it would be
+        // impossible to trigger it.
+        if actions
+            .iter()
+            .any(|a| matches!(a, Action::ToggleKeyboardShortcutsInhibit))
+        {
+            allow_inhibiting = false;
+        }
+
+        Ok(Self {
+            key,
+            actions,
+            repeat,
+            cooldown,
+            allow_when_locked,
+            allow_inhibiting,
+            hotkey_overlay_title,
+        })
     }
 }
 
@@ -1096,6 +1104,114 @@ impl FromStr for Key {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_multiple_actions_in_order() {
+        let config = crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+G { focus-column-right; consume-or-expel-window-left; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.binds.0.len(), 1);
+        assert_eq!(
+            config.binds.0[0].actions,
+            [Action::FocusColumnRight, Action::ConsumeOrExpelWindowLeft],
+        );
+    }
+
+    #[test]
+    fn parse_bind_with_no_actions_still_errors() {
+        assert!(crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+G { }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn parse_bad_action_among_several_keeps_the_others() {
+        // Two bad actions in the middle must not swallow each other's, or the good
+        // action's, decoding: both bad names must be reported as separate errors,
+        // which is what actually exercises the continue-on-error loop. knuffel's
+        // generic "expected one of N others" message text doesn't embed the bad
+        // node's name, so we recover it from each diagnostic's label span instead.
+        use miette::Diagnostic;
+
+        let config_text = r#"
+            binds {
+                Mod+G { focus-column-right; not-a-real-action; also-not-real; close-window; }
+            }
+            "#;
+
+        let err = crate::Config::parse_mem(config_text).unwrap_err();
+
+        let bad_snippets: Vec<&str> = err
+            .related()
+            .into_iter()
+            .flatten()
+            .flat_map(|e| e.labels().into_iter().flatten())
+            .map(|label| &config_text[label.offset()..label.offset() + label.len()])
+            .collect();
+
+        assert!(
+            bad_snippets.contains(&"not-a-real-action"),
+            "expected a label pointing at `not-a-real-action`, got: {bad_snippets:?}"
+        );
+        assert!(
+            bad_snippets.contains(&"also-not-real"),
+            "expected a label pointing at `also-not-real`, got: {bad_snippets:?}"
+        );
+    }
+
+    #[test]
+    fn allow_when_locked_rejected_on_mixed_bind() {
+        // Every action must be spawn/spawn-sh, otherwise allow-when-locked would let a
+        // non-spawn action run from the lock screen.
+        assert!(crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+X allow-when-locked=true { spawn "foo"; quit; }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn allow_when_locked_accepted_on_all_spawn_bind() {
+        let config = crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+X allow-when-locked=true { spawn "foo"; spawn-sh "bar"; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert!(config.binds.0[0].allow_when_locked);
+        assert_eq!(config.binds.0[0].actions.len(), 2);
+    }
+
+    #[test]
+    fn toggle_inhibit_anywhere_in_list_forces_allow_inhibiting_false() {
+        let config = crate::Config::parse_mem(
+            r#"
+            binds {
+                Mod+Escape { close-window; toggle-keyboard-shortcuts-inhibit; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert!(!config.binds.0[0].allow_inhibiting);
+    }
 
     #[test]
     fn parse_window_shader_actions() {

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -22,7 +22,7 @@ pub struct Binds(pub Vec<Bind>);
 #[derive(Debug, Clone, PartialEq)]
 pub struct Bind {
     pub key: Key,
-    pub action: Action,
+    pub actions: Vec<Action>,
     pub repeat: bool,
     pub cooldown: Option<Duration>,
     pub allow_when_locked: bool,
@@ -929,7 +929,7 @@ where
         // even if their contents are not valid.
         let dummy = Self {
             key,
-            action: Action::Spawn(vec![]),
+            actions: Vec::new(),
             repeat: true,
             cooldown: None,
             allow_when_locked: false,
@@ -965,7 +965,7 @@ where
 
                     Ok(Self {
                         key,
-                        action,
+                        actions: vec![action],
                         repeat,
                         cooldown,
                         allow_when_locked,
@@ -1108,7 +1108,12 @@ mod tests {
             "#,
         )
         .unwrap();
-        let actions: Vec<_> = config.binds.0.iter().map(|b| b.action.clone()).collect();
+        let actions: Vec<_> = config
+            .binds
+            .0
+            .iter()
+            .map(|b| b.actions[0].clone())
+            .collect();
         assert_eq!(
             actions,
             [Action::ToggleWindowShader, Action::CycleWindowShader]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -711,7 +711,7 @@ mod tests {
             .binds
             .0
             .iter()
-            .map(|bind| bind.action.clone())
+            .map(|bind| bind.actions[0].clone())
             .collect();
         let name = || "scratch".to_string();
         assert_eq!(
@@ -2184,7 +2184,9 @@ mod tests {
                                 COMPOSITOR,
                             ),
                         },
-                        action: ToggleKeyboardShortcutsInhibit,
+                        actions: [
+                            ToggleKeyboardShortcutsInhibit,
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2204,7 +2206,9 @@ mod tests {
                                 SHIFT | COMPOSITOR,
                             ),
                         },
-                        action: ToggleKeyboardShortcutsInhibit,
+                        actions: [
+                            ToggleKeyboardShortcutsInhibit,
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2220,11 +2224,13 @@ mod tests {
                                 COMPOSITOR,
                             ),
                         },
-                        action: Spawn(
-                            [
-                                "alacritty",
-                            ],
-                        ),
+                        actions: [
+                            Spawn(
+                                [
+                                    "alacritty",
+                                ],
+                            ),
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: true,
@@ -2240,7 +2246,9 @@ mod tests {
                                 COMPOSITOR,
                             ),
                         },
-                        action: CloseWindow,
+                        actions: [
+                            CloseWindow,
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2258,7 +2266,9 @@ mod tests {
                                 SHIFT | COMPOSITOR,
                             ),
                         },
-                        action: FocusMonitorLeft,
+                        actions: [
+                            FocusMonitorLeft,
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2274,9 +2284,11 @@ mod tests {
                                 SHIFT | COMPOSITOR,
                             ),
                         },
-                        action: FocusMonitor(
-                            "eDP-1",
-                        ),
+                        actions: [
+                            FocusMonitor(
+                                "eDP-1",
+                            ),
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2292,7 +2304,9 @@ mod tests {
                                 CTRL | SHIFT | COMPOSITOR,
                             ),
                         },
-                        action: MoveWindowToMonitorRight,
+                        actions: [
+                            MoveWindowToMonitorRight,
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2308,9 +2322,11 @@ mod tests {
                                 CTRL | ALT | COMPOSITOR,
                             ),
                         },
-                        action: MoveWindowToMonitor(
-                            "eDP-1",
-                        ),
+                        actions: [
+                            MoveWindowToMonitor(
+                                "eDP-1",
+                            ),
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2326,9 +2342,11 @@ mod tests {
                                 CTRL | ALT | COMPOSITOR,
                             ),
                         },
-                        action: MoveColumnToMonitor(
-                            "DP-1",
-                        ),
+                        actions: [
+                            MoveColumnToMonitor(
+                                "DP-1",
+                            ),
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2344,7 +2362,9 @@ mod tests {
                                 COMPOSITOR,
                             ),
                         },
-                        action: ConsumeWindowIntoColumn,
+                        actions: [
+                            ConsumeWindowIntoColumn,
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2360,11 +2380,13 @@ mod tests {
                                 COMPOSITOR,
                             ),
                         },
-                        action: FocusWorkspace(
-                            Index(
-                                1,
+                        actions: [
+                            FocusWorkspace(
+                                Index(
+                                    1,
+                                ),
                             ),
-                        ),
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2380,11 +2402,13 @@ mod tests {
                                 SHIFT | COMPOSITOR,
                             ),
                         },
-                        action: FocusWorkspace(
-                            Name(
-                                "workspace-1",
+                        actions: [
+                            FocusWorkspace(
+                                Name(
+                                    "workspace-1",
+                                ),
                             ),
-                        ),
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2400,9 +2424,11 @@ mod tests {
                                 SHIFT | COMPOSITOR,
                             ),
                         },
-                        action: Quit(
-                            true,
-                        ),
+                        actions: [
+                            Quit(
+                                true,
+                            ),
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2416,7 +2442,9 @@ mod tests {
                                 COMPOSITOR,
                             ),
                         },
-                        action: FocusWorkspaceDown,
+                        actions: [
+                            FocusWorkspaceDown,
+                        ],
                         repeat: true,
                         cooldown: Some(
                             150ms,
@@ -2434,9 +2462,11 @@ mod tests {
                                 ALT | SUPER,
                             ),
                         },
-                        action: SpawnSh(
-                            "pkill orca || exec orca",
-                        ),
+                        actions: [
+                            SpawnSh(
+                                "pkill orca || exec orca",
+                            ),
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: true,
@@ -2557,13 +2587,15 @@ mod tests {
                                 ALT,
                             ),
                         },
-                        action: MruAdvance {
-                            direction: Forward,
-                            scope: None,
-                            filter: Some(
-                                All,
-                            ),
-                        },
+                        actions: [
+                            MruAdvance {
+                                direction: Forward,
+                                scope: None,
+                                filter: Some(
+                                    All,
+                                ),
+                            },
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2579,13 +2611,15 @@ mod tests {
                                 ALT,
                             ),
                         },
-                        action: MruAdvance {
-                            direction: Forward,
-                            scope: None,
-                            filter: Some(
-                                AppId,
-                            ),
-                        },
+                        actions: [
+                            MruAdvance {
+                                direction: Forward,
+                                scope: None,
+                                filter: Some(
+                                    AppId,
+                                ),
+                            },
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
@@ -2601,15 +2635,17 @@ mod tests {
                                 SUPER,
                             ),
                         },
-                        action: MruAdvance {
-                            direction: Forward,
-                            scope: Some(
-                                Output,
-                            ),
-                            filter: Some(
-                                All,
-                            ),
-                        },
+                        actions: [
+                            MruAdvance {
+                                direction: Forward,
+                                scope: Some(
+                                    Output,
+                                ),
+                                filter: Some(
+                                    All,
+                                ),
+                            },
+                        ],
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,

--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -148,7 +148,7 @@ impl From<MruBind> for Bind {
     fn from(x: MruBind) -> Self {
         Self {
             key: x.key,
-            action: Action::from(x.action),
+            actions: vec![Action::from(x.action)],
             repeat: true,
             cooldown: None,
             allow_when_locked: false,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -89,6 +89,12 @@ pub enum Request {
     PickColor,
     /// Perform an action.
     Action(Action),
+    /// Perform several actions as one atomic sequence.
+    ///
+    /// All actions are validated before any of them runs; if any is invalid, none run. The
+    /// actions then run in order with nothing else running in between, which is what
+    /// distinguishes this from several [`Request::Action`] calls.
+    Actions(Vec<Action>),
     /// Change output configuration temporarily.
     ///
     /// The configuration is changed temporarily and not saved into the config file. If the output
@@ -2187,6 +2193,24 @@ impl OutputAction {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn actions_request_round_trips() {
+        let request = Request::Actions(vec![
+            Action::FocusColumnRight {},
+            Action::CloseWindow { id: None },
+        ]);
+
+        let json = serde_json::to_string(&request).unwrap();
+        let back: Request = serde_json::from_str(&json).unwrap();
+
+        let Request::Actions(actions) = back else {
+            panic!("expected Actions, got {back:?}");
+        };
+        assert_eq!(actions.len(), 2);
+        assert!(matches!(actions[0], Action::FocusColumnRight {}));
+        assert!(matches!(actions[1], Action::CloseWindow { id: None }));
+    }
 
     #[test]
     fn parse_size_change() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -251,7 +251,10 @@ mod tests {
             String::from("not-a-real-action"),
         ];
         let err = parse_actions(&args, "").unwrap_err().to_string();
-        assert!(err.contains('2'), "error should name argument 2: {err}");
+        assert!(
+            err.contains("argument 2"),
+            "error should name argument 2: {err}"
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,6 +86,18 @@ pub enum Msg {
         #[command(subcommand)]
         action: Action,
     },
+    /// Perform several actions as one atomic sequence.
+    ///
+    /// Each argument is one action, for example:
+    ///
+    ///   niri msg actions "toggle-workspace-visibility stash" "focus-workspace stash"
+    ///
+    /// With no arguments, actions are read from stdin, one per line.
+    Actions {
+        /// One action per argument. Reads actions from stdin, one per line, if empty.
+        #[arg()]
+        actions: Vec<String>,
+    },
     /// Change output configuration temporarily.
     ///
     /// The configuration is changed temporarily and not saved into the config file. If the output
@@ -135,5 +147,115 @@ impl TryFrom<CompletionShell> for Shell {
             CompletionShell::Zsh => Ok(Shell::Zsh),
             CompletionShell::Nushell => Err("Nushell should be handled separately"),
         }
+    }
+}
+
+/// Wrapper that lets a single `Action` be parsed from a bare word list.
+///
+/// `Action` is a clap `Subcommand`, so it needs a `Parser` around it, and
+/// `no_binary_name` so that the first word is read as the subcommand rather than as
+/// argv[0].
+#[derive(clap::Parser)]
+#[command(name = "", no_binary_name = true)]
+struct ActionParser {
+    #[command(subcommand)]
+    action: Action,
+}
+
+/// Parses one action from an already-lexed word list.
+pub fn parse_action_words(words: Vec<String>) -> anyhow::Result<Action> {
+    use clap::Parser as _;
+
+    Ok(ActionParser::try_parse_from(words)?.action)
+}
+
+/// Parses a batch of actions from CLI arguments, falling back to stdin when there are none.
+///
+/// Argument form and stdin form must produce identical output.
+pub fn parse_actions(args: &[String], stdin: &str) -> anyhow::Result<Vec<Action>> {
+    use anyhow::{anyhow, Context as _};
+
+    let sources: Vec<(String, String)> = if args.is_empty() {
+        stdin
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| !line.trim().is_empty())
+            .map(|(idx, line)| (format!("stdin line {}", idx + 1), line.to_owned()))
+            .collect()
+    } else {
+        args.iter()
+            .enumerate()
+            .map(|(idx, arg)| (format!("argument {}", idx + 1), arg.clone()))
+            .collect()
+    };
+
+    if sources.is_empty() {
+        return Err(anyhow!(
+            "no actions given; pass one action per argument, or one per line on stdin"
+        ));
+    }
+
+    let mut actions = Vec::with_capacity(sources.len());
+    for (label, text) in sources {
+        let words =
+            shlex::split(&text).ok_or_else(|| anyhow!("{label}: unbalanced quotes in {text:?}"))?;
+        if words.is_empty() {
+            return Err(anyhow!("{label}: empty action"));
+        }
+        actions.push(parse_action_words(words).with_context(|| label.clone())?);
+    }
+
+    Ok(actions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_and_stdin_produce_the_same_actions() {
+        let args = vec![
+            String::from("toggle-workspace-visibility stash"),
+            String::from("focus-workspace stash"),
+        ];
+        let from_args = parse_actions(&args, "").unwrap();
+
+        let stdin = "toggle-workspace-visibility stash\nfocus-workspace stash\n";
+        let from_stdin = parse_actions(&[], stdin).unwrap();
+
+        assert_eq!(from_args.len(), 2);
+        assert_eq!(format!("{from_args:?}"), format!("{from_stdin:?}"));
+    }
+
+    #[test]
+    fn blank_stdin_lines_are_skipped() {
+        let stdin = "focus-column-right\n\n   \nclose-window\n";
+        let actions = parse_actions(&[], stdin).unwrap();
+        assert_eq!(actions.len(), 2);
+    }
+
+    #[test]
+    fn quoted_arguments_survive_lexing() {
+        let args = vec![String::from(r#"spawn -- sh -c "echo hello world""#)];
+        let actions = parse_actions(&args, "").unwrap();
+        let Action::Spawn { command } = &actions[0] else {
+            panic!("expected Spawn, got {:?}", actions[0]);
+        };
+        assert_eq!(command, &["sh", "-c", "echo hello world"]);
+    }
+
+    #[test]
+    fn a_bad_action_names_its_position() {
+        let args = vec![
+            String::from("focus-column-right"),
+            String::from("not-a-real-action"),
+        ];
+        let err = parse_actions(&args, "").unwrap_err().to_string();
+        assert!(err.contains('2'), "error should name argument 2: {err}");
+    }
+
+    #[test]
+    fn no_args_and_no_stdin_is_an_error() {
+        assert!(parse_actions(&[], "").is_err());
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -684,12 +684,17 @@ impl State {
 
     pub fn handle_bind(&mut self, bind: Bind) {
         let Some(cooldown) = bind.cooldown else {
-            self.do_action(bind.action, bind.allow_when_locked);
+            self.do_actions(bind.actions, bind.allow_when_locked);
             return;
         };
 
         // Check this first so that it doesn't trigger the cooldown.
-        if self.niri.is_locked() && !(bind.allow_when_locked || allowed_when_locked(&bind.action)) {
+        //
+        // Run the bind if *any* of its actions would be allowed; do_action skips the rest
+        // individually.
+        if self.niri.is_locked()
+            && !(bind.allow_when_locked || bind.actions.iter().any(allowed_when_locked))
+        {
             return;
         }
 
@@ -710,8 +715,14 @@ impl State {
                     .unwrap();
                 entry.insert(token);
 
-                self.do_action(bind.action, bind.allow_when_locked);
+                self.do_actions(bind.actions, bind.allow_when_locked);
             }
+        }
+    }
+
+    pub fn do_actions(&mut self, actions: Vec<Action>, allow_when_locked: bool) {
+        for action in actions {
+            self.do_action(action, allow_when_locked);
         }
     }
 
@@ -3156,7 +3167,7 @@ impl State {
                     find_configured_bind(bindings, mod_key, trigger, mods)
                 })
                 .filter(|bind| {
-                    !self.niri.screenshot_ui.is_open() || allowed_during_screenshot(&bind.action)
+                    !self.niri.screenshot_ui.is_open() || bind_allowed_during_screenshot(bind)
                 }) {
                     self.niri.suppressed_buttons.insert(button_code);
                     self.handle_bind(bind.clone());
@@ -3539,7 +3550,7 @@ impl State {
                                     trigger: Trigger::WheelScrollLeft,
                                     modifiers: Modifiers::empty(),
                                 },
-                                action: Action::FocusColumnLeftUnderMouse,
+                                actions: vec![Action::FocusColumnLeftUnderMouse],
                                 repeat: true,
                                 cooldown: None,
                                 allow_when_locked: false,
@@ -3551,7 +3562,7 @@ impl State {
                                     trigger: Trigger::WheelScrollRight,
                                     modifiers: Modifiers::empty(),
                                 },
-                                action: Action::FocusColumnRightUnderMouse,
+                                actions: vec![Action::FocusColumnRightUnderMouse],
                                 repeat: true,
                                 cooldown: None,
                                 allow_when_locked: false,
@@ -3571,7 +3582,7 @@ impl State {
                             )
                             .filter(|bind| {
                                 !self.niri.screenshot_ui.is_open()
-                                    || allowed_during_screenshot(&bind.action)
+                                    || bind_allowed_during_screenshot(bind)
                             });
                             let bind_right = find_configured_bind(
                                 bindings,
@@ -3581,7 +3592,7 @@ impl State {
                             )
                             .filter(|bind| {
                                 !self.niri.screenshot_ui.is_open()
-                                    || allowed_during_screenshot(&bind.action)
+                                    || bind_allowed_during_screenshot(bind)
                             });
                             (bind_left, bind_right)
                         };
@@ -3608,7 +3619,7 @@ impl State {
                                 trigger: Trigger::WheelScrollUp,
                                 modifiers: Modifiers::empty(),
                             },
-                            action: Action::FocusWorkspaceUpUnderMouse,
+                            actions: vec![Action::FocusWorkspaceUpUnderMouse],
                             repeat: true,
                             cooldown: Some(Duration::from_millis(50)),
                             allow_when_locked: false,
@@ -3620,7 +3631,7 @@ impl State {
                                 trigger: Trigger::WheelScrollDown,
                                 modifiers: Modifiers::empty(),
                             },
-                            action: Action::FocusWorkspaceDownUnderMouse,
+                            actions: vec![Action::FocusWorkspaceDownUnderMouse],
                             repeat: true,
                             cooldown: Some(Duration::from_millis(50)),
                             allow_when_locked: false,
@@ -3651,7 +3662,7 @@ impl State {
                                 trigger: Trigger::WheelScrollUp,
                                 modifiers: Modifiers::empty(),
                             },
-                            action: Action::FocusColumnLeftUnderMouse,
+                            actions: vec![Action::FocusColumnLeftUnderMouse],
                             repeat: true,
                             cooldown: Some(Duration::from_millis(50)),
                             allow_when_locked: false,
@@ -3663,7 +3674,7 @@ impl State {
                                 trigger: Trigger::WheelScrollDown,
                                 modifiers: Modifiers::empty(),
                             },
-                            action: Action::FocusColumnRightUnderMouse,
+                            actions: vec![Action::FocusColumnRightUnderMouse],
                             repeat: true,
                             cooldown: Some(Duration::from_millis(50)),
                             allow_when_locked: false,
@@ -3683,13 +3694,13 @@ impl State {
                         )
                         .filter(|bind| {
                             !self.niri.screenshot_ui.is_open()
-                                || allowed_during_screenshot(&bind.action)
+                                || bind_allowed_during_screenshot(bind)
                         });
                         let bind_down =
                             find_configured_bind(bindings, mod_key, Trigger::WheelScrollDown, mods)
                                 .filter(|bind| {
                                     !self.niri.screenshot_ui.is_open()
-                                        || allowed_during_screenshot(&bind.action)
+                                        || bind_allowed_during_screenshot(bind)
                                 });
                         (bind_up, bind_down)
                     };
@@ -3835,14 +3846,13 @@ impl State {
                         mods,
                     )
                     .filter(|bind| {
-                        !self.niri.screenshot_ui.is_open()
-                            || allowed_during_screenshot(&bind.action)
+                        !self.niri.screenshot_ui.is_open() || bind_allowed_during_screenshot(bind)
                     });
                     let bind_right =
                         find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollRight, mods)
                             .filter(|bind| {
                                 !self.niri.screenshot_ui.is_open()
-                                    || allowed_during_screenshot(&bind.action)
+                                    || bind_allowed_during_screenshot(bind)
                             });
                     drop(config);
 
@@ -3873,14 +3883,13 @@ impl State {
                         mods,
                     )
                     .filter(|bind| {
-                        !self.niri.screenshot_ui.is_open()
-                            || allowed_during_screenshot(&bind.action)
+                        !self.niri.screenshot_ui.is_open() || bind_allowed_during_screenshot(bind)
                     });
                     let bind_down =
                         find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollDown, mods)
                             .filter(|bind| {
                                 !self.niri.screenshot_ui.is_open()
-                                    || allowed_during_screenshot(&bind.action)
+                                    || bind_allowed_during_screenshot(bind)
                             });
                     drop(config);
 
@@ -4296,7 +4305,7 @@ impl State {
                         }
                         .filter(|bind| {
                             !self.niri.screenshot_ui.is_open()
-                                || allowed_during_screenshot(&bind.action)
+                                || bind_allowed_during_screenshot(bind)
                         });
                         if let Some(bind) = bind {
                             self.niri.suppressed_buttons.insert(button);
@@ -4925,7 +4934,7 @@ fn should_intercept_key<'a>(
         let mut use_screenshot_ui_action = true;
 
         if let Some(bind) = &final_bind {
-            if allowed_during_screenshot(&bind.action) {
+            if bind_allowed_during_screenshot(bind) {
                 use_screenshot_ui_action = false;
             }
         }
@@ -4938,7 +4947,7 @@ fn should_intercept_key<'a>(
                         // Not entirely correct but it doesn't matter in how we currently use it.
                         modifiers: Modifiers::empty(),
                     },
-                    action,
+                    actions: vec![action],
                     repeat: true,
                     cooldown: None,
                     allow_when_locked: false,
@@ -5002,7 +5011,7 @@ fn find_bind<'a>(
                 trigger: Trigger::Keysym(modified),
                 modifiers: Modifiers::empty(),
             },
-            action,
+            actions: vec![action],
             repeat: true,
             cooldown: None,
             allow_when_locked: false,
@@ -5219,6 +5228,12 @@ fn allowed_during_screenshot(action: &Action) -> bool {
     )
 }
 
+/// A bind is usable while the screenshot UI is open only if *every* one of its actions is.
+/// The screenshot UI must never be handed a bind it can only half-run.
+fn bind_allowed_during_screenshot(bind: &Bind) -> bool {
+    bind.actions.iter().all(allowed_during_screenshot)
+}
+
 fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
     let mods = modifiers_from_state(mods);
     if !mods.is_empty() {
@@ -5245,7 +5260,7 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
             trigger: Trigger::Keysym(raw),
             modifiers: Modifiers::empty(),
         },
-        action,
+        actions: vec![action],
         repeat,
         cooldown: None,
         allow_when_locked: false,
@@ -5685,7 +5700,7 @@ mod tests {
                 trigger: Trigger::Keysym(close_keysym),
                 modifiers: Modifiers::COMPOSITOR | Modifiers::CTRL,
             },
-            action: Action::CloseWindow,
+            actions: vec![Action::CloseWindow],
             repeat: true,
             cooldown: None,
             allow_when_locked: false,
@@ -5749,9 +5764,9 @@ mod tests {
         assert!(matches!(
             filter,
             FilterResult::Intercept(Some(Bind {
-                action: Action::CloseWindow,
+                actions,
                 ..
-            }))
+            })) if actions.as_slice() == [Action::CloseWindow]
         ));
         assert!(suppressed_keys.contains(&close_key_code));
 
@@ -5783,9 +5798,9 @@ mod tests {
         assert!(matches!(
             filter,
             FilterResult::Intercept(Some(Bind {
-                action: Action::CloseWindow,
+                actions,
                 ..
-            }))
+            })) if actions.as_slice() == [Action::CloseWindow]
         ));
 
         let filter = none_key_event(&mut suppressed_keys, mods, true);
@@ -5803,9 +5818,9 @@ mod tests {
         assert!(matches!(
             filter,
             FilterResult::Intercept(Some(Bind {
-                action: Action::CloseWindow,
+                actions,
                 ..
-            }))
+            })) if actions.as_slice() == [Action::CloseWindow]
         ));
 
         mods = Default::default();
@@ -5850,9 +5865,9 @@ mod tests {
         assert!(matches!(
             filter,
             FilterResult::Intercept(Some(Bind {
-                action: Action::CloseWindow,
+                actions,
                 ..
-            }))
+            })) if actions.as_slice() == [Action::CloseWindow]
         ));
         assert!(suppressed_keys.contains(&close_key_code));
 
@@ -5871,7 +5886,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::q),
                     modifiers: Modifiers::COMPOSITOR,
                 },
-                action: Action::CloseWindow,
+                actions: vec![Action::CloseWindow],
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,
@@ -5883,7 +5898,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::h),
                     modifiers: Modifiers::SUPER,
                 },
-                action: Action::FocusColumnLeft,
+                actions: vec![Action::FocusColumnLeft],
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,
@@ -5895,7 +5910,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::j),
                     modifiers: Modifiers::empty(),
                 },
-                action: Action::FocusWindowDown,
+                actions: vec![Action::FocusWindowDown],
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,
@@ -5907,7 +5922,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::k),
                     modifiers: Modifiers::COMPOSITOR | Modifiers::SUPER,
                 },
-                action: Action::FocusWindowUp,
+                actions: vec![Action::FocusWindowUp],
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,
@@ -5919,7 +5934,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::l),
                     modifiers: Modifiers::SUPER | Modifiers::ALT,
                 },
-                action: Action::FocusColumnRight,
+                actions: vec![Action::FocusColumnRight],
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -29,6 +29,34 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         }
     }
 
+    // Resolve `niri msg actions` before the request match, since it may read stdin.
+    let batched_actions = if let Msg::Actions { actions } = &msg {
+        use std::io::Read as _;
+
+        let mut stdin = String::new();
+        if actions.is_empty() {
+            std::io::stdin()
+                .read_to_string(&mut stdin)
+                .context("error reading actions from stdin")?;
+        }
+
+        let mut parsed = crate::cli::parse_actions(actions, &stdin)?;
+        // For actions taking paths, prepend the niri CLI's working directory.
+        for action in &mut parsed {
+            if let Action::Screenshot { path, .. }
+            | Action::ScreenshotScreen { path, .. }
+            | Action::ScreenshotWindow { path, .. } = action
+            {
+                if let Some(path) = path {
+                    ensure_absolute_path(path).context("error making the path absolute")?;
+                }
+            }
+        }
+        Some(parsed)
+    } else {
+        None
+    };
+
     let request = match &msg {
         Msg::Version => Request::Version,
         Msg::Outputs => Request::Outputs,
@@ -37,6 +65,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::PickWindow => Request::PickWindow,
         Msg::PickColor => Request::PickColor,
         Msg::Action { action } => Request::Action(action.clone()),
+        Msg::Actions { .. } => Request::Actions(batched_actions.clone().unwrap()),
         Msg::Output { output, action } => Request::Output {
             output: output.clone(),
             action: action.clone(),
@@ -319,6 +348,11 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
             }
         }
         Msg::Action { .. } => {
+            let Response::Handled = response else {
+                bail!("unexpected response: expected Handled, got {response:?}");
+            };
+        }
+        Msg::Actions { .. } => {
             let Response::Handled = response else {
                 bail!("unexpected response: expected Handled, got {response:?}");
             };

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1038,3 +1038,54 @@ impl State {
         server.send_event(event);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_action_passes_validation() {
+        assert!(validate_action(&Action::FocusColumnRight {}).is_ok());
+    }
+
+    #[test]
+    fn relative_screenshot_path_is_rejected() {
+        let action = Action::Screenshot {
+            show_pointer: true,
+            path: Some("relative/path.png".to_owned()),
+        };
+        let err = validate_action(&action).unwrap_err();
+        assert!(
+            err.contains("must be absolute"),
+            "error should mention the path must be absolute: {err}"
+        );
+    }
+
+    #[test]
+    fn batch_error_names_the_one_based_index_of_the_bad_action() {
+        // Mirrors the labelling done in the `Request::Actions` handler: the first
+        // invalid action in the batch, at position two, must be reported as
+        // "action 2", not "action 1" (0-based) or the unlabelled underlying error.
+        let actions = [
+            Action::FocusColumnRight {},
+            Action::Screenshot {
+                show_pointer: true,
+                path: Some("relative/path.png".to_owned()),
+            },
+        ];
+
+        let mut result = Ok(());
+        for (idx, action) in actions.iter().enumerate() {
+            if let Err(err) = validate_action(action) {
+                result = Err(format!("action {}: {err}", idx + 1));
+                break;
+            }
+        }
+
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("action 2"),
+            "error should name action 2 (1-based): {err}"
+        );
+    }
+}

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -410,6 +410,33 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let _ = rx.recv().await;
             Response::Handled
         }
+        Request::Actions(actions) => {
+            // Validate everything up front: an invalid action anywhere rejects the whole
+            // batch, so a partial sequence never runs.
+            for (idx, action) in actions.iter().enumerate() {
+                validate_action(action).map_err(|err| format!("action {}: {err}", idx + 1))?;
+            }
+
+            let (tx, rx) = async_channel::bounded(1);
+
+            let actions: Vec<niri_config::Action> =
+                actions.into_iter().map(niri_config::Action::from).collect();
+            // One idle callback for the whole batch. This is the point of the request:
+            // nothing can interleave between the actions. Queuing one callback per action
+            // would not give that guarantee.
+            ctx.event_loop.insert_idle(move |state| {
+                // Make sure some logic like workspace clean-up has a chance to run before
+                // doing actions.
+                state.niri.advance_animations();
+                state.do_actions(actions, false);
+                let _ = tx.send_blocking(());
+            });
+
+            // Wait until the actions have been processed before returning, for the same
+            // reason as the single-action request.
+            let _ = rx.recv().await;
+            Response::Handled
+        }
         Request::Output { output, action } => {
             action.validate()?;
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -413,9 +413,7 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
         Request::Actions(actions) => {
             // Validate everything up front: an invalid action anywhere rejects the whole
             // batch, so a partial sequence never runs.
-            for (idx, action) in actions.iter().enumerate() {
-                validate_action(action).map_err(|err| format!("action {}: {err}", idx + 1))?;
-            }
+            validate_actions(&actions)?;
 
             let (tx, rx) = async_channel::bounded(1);
 
@@ -521,6 +519,15 @@ fn validate_action(action: &Action) -> Result<(), String> {
         }
     }
 
+    Ok(())
+}
+
+/// Validates every action in a batch before any of them runs, labelling a failure with the
+/// 1-based position of the offending action.
+fn validate_actions(actions: &[Action]) -> Result<(), String> {
+    for (idx, action) in actions.iter().enumerate() {
+        validate_action(action).map_err(|err| format!("action {}: {err}", idx + 1))?;
+    }
     Ok(())
 }
 
@@ -1074,15 +1081,7 @@ mod tests {
             },
         ];
 
-        let mut result = Ok(());
-        for (idx, action) in actions.iter().enumerate() {
-            if let Err(err) = validate_action(action) {
-                result = Err(format!("action {}: {err}", idx + 1));
-                break;
-            }
-        }
-
-        let err = result.unwrap_err();
+        let err = validate_actions(&actions).unwrap_err();
         assert!(
             err.contains("action 2"),
             "error should name action 2 (1-based): {err}"

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -320,8 +320,13 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
     }
 
     if config.hotkey_overlay.hide_not_bound {
-        // Only keep actions that have been bound
-        actions.retain(|&action| binds.iter().any(|bind| bind.actions.contains(action)))
+        // Only keep actions that have been bound. Multi-action binds are not shown in the
+        // hotkey overlay, so an action must be the sole action of some bind to count.
+        actions.retain(|&action| {
+            binds
+                .iter()
+                .any(|bind| bind.actions.as_slice() == std::slice::from_ref(action))
+        })
     }
 
     actions

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -158,7 +158,8 @@ fn format_bind(binds: &[Bind], action: &Action) -> Option<(Option<Key>, String)>
     let mut found_null_title = false;
 
     for bind in binds {
-        if bind.action != *action {
+        // Multi-action binds are not shown in the hotkey overlay.
+        if bind.actions.as_slice() != std::slice::from_ref(action) {
             continue;
         }
 
@@ -202,9 +203,15 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
 
     // Prefer Quit(false) if found, otherwise try Quit(true), and if there's neither, fall back to
     // Quit(false).
-    if binds.iter().any(|bind| bind.action == Action::Quit(false)) {
+    if binds
+        .iter()
+        .any(|bind| bind.actions.as_slice() == [Action::Quit(false)])
+    {
         actions.push(&Action::Quit(false));
-    } else if binds.iter().any(|bind| bind.action == Action::Quit(true)) {
+    } else if binds
+        .iter()
+        .any(|bind| bind.actions.as_slice() == [Action::Quit(true)])
+    {
         actions.push(&Action::Quit(true));
     } else {
         actions.push(&Action::Quit(false));
@@ -221,30 +228,38 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
     ]);
 
     // Prefer move-column-to-workspace-down, but fall back to move-window-to-workspace-down.
-    if let Some(bind) = binds
-        .iter()
-        .find(|bind| matches!(bind.action, Action::MoveColumnToWorkspaceDown(_)))
-    {
-        actions.push(&bind.action);
-    } else if binds
-        .iter()
-        .any(|bind| matches!(bind.action, Action::MoveWindowToWorkspaceDown(_)))
-    {
+    if let Some(bind) = binds.iter().find(|bind| {
+        matches!(
+            bind.actions.as_slice(),
+            [Action::MoveColumnToWorkspaceDown(_)]
+        )
+    }) {
+        actions.push(&bind.actions[0]);
+    } else if binds.iter().any(|bind| {
+        matches!(
+            bind.actions.as_slice(),
+            [Action::MoveWindowToWorkspaceDown(_)]
+        )
+    }) {
         actions.push(&Action::MoveWindowToWorkspaceDown(true));
     } else {
         actions.push(&Action::MoveColumnToWorkspaceDown(true));
     }
 
     // Same for -up.
-    if let Some(bind) = binds
-        .iter()
-        .find(|bind| matches!(bind.action, Action::MoveColumnToWorkspaceUp(_)))
-    {
-        actions.push(&bind.action);
-    } else if binds
-        .iter()
-        .any(|bind| matches!(bind.action, Action::MoveWindowToWorkspaceUp(_)))
-    {
+    if let Some(bind) = binds.iter().find(|bind| {
+        matches!(
+            bind.actions.as_slice(),
+            [Action::MoveColumnToWorkspaceUp(_)]
+        )
+    }) {
+        actions.push(&bind.actions[0]);
+    } else if binds.iter().any(|bind| {
+        matches!(
+            bind.actions.as_slice(),
+            [Action::MoveWindowToWorkspaceUp(_)]
+        )
+    }) {
         actions.push(&Action::MoveWindowToWorkspaceUp(true));
     } else {
         actions.push(&Action::MoveColumnToWorkspaceUp(true));
@@ -264,31 +279,39 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
     // Screenshot is not as important, can omit if not bound.
     if let Some(bind) = binds
         .iter()
-        .find(|bind| matches!(bind.action, Action::Screenshot(_, _)))
+        .find(|bind| matches!(bind.actions.as_slice(), [Action::Screenshot(_, _)]))
     {
-        actions.push(&bind.action);
+        actions.push(&bind.actions[0]);
     }
 
     // Add actions with a custom hotkey-overlay-title.
     for bind in binds {
         if matches!(bind.hotkey_overlay_title, Some(Some(_))) {
+            // Multi-action binds don't have a single action to show.
+            let [bind_action] = bind.actions.as_slice() else {
+                continue;
+            };
+
             // Avoid duplicate actions.
-            if !actions.contains(&&bind.action) {
-                actions.push(&bind.action);
+            if !actions.contains(&bind_action) {
+                actions.push(bind_action);
             }
         }
     }
 
     // Add the spawn actions.
     for bind in binds.iter().filter(|bind| {
-        matches!(bind.action, Action::Spawn(_) | Action::SpawnSh(_))
+        matches!(
+            bind.actions.as_slice(),
+            [Action::Spawn(_)] | [Action::SpawnSh(_)]
+        )
             // Only show binds with Mod or Super to filter out stuff like volume up/down.
             && (bind.key.modifiers.contains(Modifiers::COMPOSITOR)
                 || bind.key.modifiers.contains(Modifiers::SUPER))
             // Also filter out wheel and touchpad scroll binds.
             && matches!(bind.key.trigger, Trigger::Keysym(_))
     }) {
-        let action = &bind.action;
+        let action = &bind.actions[0];
 
         // We only show one bind for each action, so we need to deduplicate the Spawn actions.
         if !actions.contains(&action) {
@@ -298,7 +321,7 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
 
     if config.hotkey_overlay.hide_not_bound {
         // Only keep actions that have been bound
-        actions.retain(|&action| binds.iter().any(|bind| bind.action == *action))
+        actions.retain(|&action| binds.iter().any(|bind| bind.actions.contains(action)))
     }
 
     actions

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -1855,7 +1855,7 @@ fn make_preset_opened_binds() -> Vec<Bind> {
                 // The modifier is filled dynamically.
                 modifiers: Modifiers::empty(),
             },
-            action,
+            actions: vec![action],
             repeat: true,
             cooldown: None,
             allow_when_locked: false,
@@ -1903,7 +1903,12 @@ fn make_dynamic_opened_binds(config: &Config) -> Vec<Bind> {
     let mut binds: HashMap<Trigger, Vec<Bind>> = HashMap::new();
 
     for bind in &config.binds.0 {
-        let action = match &bind.action {
+        // Multi-action binds don't map onto a single MRU action.
+        let [bind_action] = bind.actions.as_slice() else {
+            continue;
+        };
+
+        let action = match bind_action {
             Action::FocusColumnRight
             | Action::FocusColumnRightOrFirst
             | Action::FocusColumnOrMonitorRight
@@ -1928,7 +1933,7 @@ fn make_dynamic_opened_binds(config: &Config) -> Vec<Bind> {
         };
 
         binds.entry(bind.key.trigger).or_default().push(Bind {
-            action,
+            actions: vec![action],
             ..bind.clone()
         });
     }


### PR DESCRIPTION
Closes #32.

Two halves, both in scope.

**Config.** A bind can list several actions, which run in source order:

```kdl
binds {
    Mod+G { focus-column-right; consume-or-expel-window-left; }
}
```

**IPC.** `niri msg actions` sends the whole list as one batch that runs with nothing interleaving between the actions — the property chaining `niri msg action` calls with `&&` cannot give you:

```sh
niri msg actions "toggle-workspace-visibility stash" "focus-workspace stash"
printf 'focus-column-right\nconsume-or-expel-window-left\n' | niri msg actions
```

That second form is the chain that prompted #24, and it removes the reason this fork keeps growing one-off `focus=true` flags to dodge chaining.

## Shape, and upstreaming

`Bind.action: Action` becomes `Bind.actions: Vec<Action>`, deliberately matching the shape YaLTeR and bbb651 already settled on upstream rather than the smaller `Action::Sequence` variant, so this can be offered to niri later. The larger mechanical diff is an accepted cost.

Decisions adopted from the upstream thread without re-litigating them: the hotkey overlay ignores multi-action binds; the CLI gets a separate `actions` subcommand because clap cannot chain subcommands; a failed `allow-when-locked` check skips just that action and the rest still run; no `or` combinator, no conditional actions, no nesting.

## Two folds worth reviewing carefully

Both are security-relevant, and the direction is deliberate:

- **`allow-when-locked` requires *every* action to be `spawn`/`spawn-sh`.** `handle_bind` passes one flag into every `do_action` call, so accepting a mixed bind such as `Mod+X allow-when-locked=true { spawn "foo"; quit; }` would let `quit` run from the lock screen. *All*, not *any*, is the only safe fold.
- **Screenshot-UI eligibility folds with *all*.** The screenshot UI must never be handed a bind it can only half-run.

The IPC batch validates every action before anything runs, then runs the whole list inside a single idle callback. One callback per action would pass every test while silently destroying the point of the feature.

## Commits

1. `3ee0ed97` — pure refactor to `Vec<Action>`, no behaviour change (the parser still rejects 2+ actions)
2. `a6fc631a` — parser accepts several actions, plus the validation folds
3. `5fd68016` — `Request::Actions` atomic IPC batch
4. `8ed2fd5f` — `niri msg actions` CLI
5. `7101252f`, `247c6055` — review findings

## Testing

`cargo test` 293 passing (was 285), `niri-config` 55 (was 49), `niri-ipc` 3. `cargo fmt`, `cargo clippy --all-targets` and `mkdocs build` in strict mode all clean.

Note on `src/ipc/server.rs`'s batch-validation test: the handler's labelling loop is extracted into `validate_actions()` so the test exercises the real code path. Verified by mutation — changing `idx + 1` to `idx` makes the test fail with `action 1: path must be absolute`, rather than passing silently.

## Not yet verified on hardware

Three checks need a live compositor and have not been run:

1. `Mod+G` with two columns open — both actions take effect, in order.
2. The `toggle-workspace-visibility` → `focus-workspace` chain switching with no intermediate flash. This is the feature's main justification.
3. A multi-action bind not appearing in the hotkey overlay.

## Known follow-ups

- `niri msg actions` with no arguments and a TTY on stdin blocks until EOF with no message.
- `Action::Spawn`'s `command` is `arg(last = true)`, so a spawn action inside a batch needs `--` (`niri msg actions "spawn -- notify-send hi"`). Documented in the wiki section, but it is a sharp edge.
- `src/ui/mru.rs` silently excludes multi-action binds from dynamic MRU binds — correct and consistent with the overlay decision, but only the overlay exclusion is documented.
