### PR TITLE
Don't open child windows onto a hidden workspace

### DIFF
--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -190,6 +190,17 @@ impl CompositorHandler for State {
                                 || output.is_none()
                                 || output.as_ref() == *parent_output
                         })
+                        // Don't follow the parent onto a hidden workspace. A hidden workspace is
+                        // somewhere the user is deliberately not looking, so a dialog opened there
+                        // is invisible and unreachable — for an authentication prompt that means
+                        // the prompt is simply lost. Fall through to the window rules and the
+                        // active workspace instead.
+                        .filter(|(mapped, _)| {
+                            !self
+                                .niri
+                                .layout
+                                .window_is_on_hidden_workspace(&mapped.window)
+                        })
                         .map(|(mapped, _)| mapped.window.clone());
 
                     // The mapped pre-commit hook deals with dma-bufs on its own.

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1525,6 +1525,15 @@ impl<W: LayoutElement> Layout<W> {
         None
     }
 
+    /// Whether `window` currently sits on a hidden workspace.
+    ///
+    /// Used when placing a child window: a dialog must not follow its parent onto a hidden
+    /// workspace, where it would be invisible and unreachable.
+    pub fn window_is_on_hidden_workspace(&self, window: &W::Id) -> bool {
+        self.workspaces()
+            .any(|(_, _, ws)| ws.hidden && ws.has_window(window))
+    }
+
     pub fn find_workspace_by_name(&self, workspace_name: &str) -> Option<(usize, &Workspace<W>)> {
         match &self.monitor_set {
             MonitorSet::Normal { ref monitors, .. } => {

--- a/src/tests/window_opening.rs
+++ b/src/tests/window_opening.rs
@@ -891,3 +891,84 @@ post-map configures:
     let _guard = settings.bind_to_scope();
     assert_snapshot!(snapshot);
 }
+
+#[test]
+fn child_window_does_not_follow_parent_onto_hidden_workspace() {
+    // A hidden workspace is by definition somewhere the user is not looking. A dialog that
+    // follows its parent there is invisible and unreachable — for a password prompt (the case
+    // this was reported for) that is a real usability failure, so the child opens where the
+    // user is working instead.
+    let config = Config::parse_mem(
+        r##"
+workspace "stash" {
+    hidden true
+}
+
+window-rule {
+    match title="parent"
+    open-on-workspace "stash"
+}
+"##,
+    )
+    .unwrap();
+
+    let mut f = Fixture::with_config(config);
+    f.add_output(1, (1280, 720));
+
+    let id = f.add_client();
+    f.roundtrip(id);
+
+    // The parent opens on the hidden workspace.
+    let window = f.client(id).create_window();
+    let parent_surface = window.surface.clone();
+    let parent = window.xdg_toplevel.clone();
+    window.set_title("parent");
+    window.commit();
+    f.roundtrip(id);
+
+    let window = f.client(id).window(&parent_surface);
+    window.attach_new_buffer();
+    window.ack_last_and_commit();
+    f.roundtrip(id);
+
+    // The child sets its parent before the initial commit, the way a dialog does.
+    let client = f.client(id);
+    let window = client.create_window();
+    let surface = window.surface.clone();
+    client.window(&surface).set_parent(Some(&parent));
+    client.window(&surface).set_title("child");
+    client.window(&surface).commit();
+    f.roundtrip(id);
+
+    let window = f.client(id).window(&surface);
+    window.attach_new_buffer();
+    window.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let niri = f.niri();
+    let mut parent_placement = None;
+    let mut child_placement = None;
+    for (_, _, ws) in niri.layout.workspaces() {
+        for win in ws.windows() {
+            let title = with_toplevel_role(win.toplevel(), |role| role.title.clone());
+            match title.as_deref() {
+                Some("parent") => parent_placement = Some((ws.name().cloned(), ws.hidden)),
+                Some("child") => child_placement = Some((ws.name().cloned(), ws.hidden)),
+                _ => (),
+            }
+        }
+    }
+
+    let (parent_ws, parent_hidden) = parent_placement.expect("parent window not found");
+    assert_eq!(parent_ws.as_deref(), Some("stash"));
+    assert!(
+        parent_hidden,
+        "test precondition failed: the parent is not on a hidden workspace"
+    );
+
+    let (child_ws, child_hidden) = child_placement.expect("child window not found");
+    assert!(
+        !child_hidden,
+        "child followed its parent onto hidden workspace {child_ws:?}"
+    );
+}


### PR DESCRIPTION
## The report

1Password's main window lives on a hidden workspace (`scratch`). The authentication prompt that appears when an app requests a credential is a **child** of that window, so it followed its parent onto the hidden workspace instead of appearing where the user was working — invisible and unreachable. For a password prompt that means the prompt is simply lost.

## Why no config could fix it

In `src/handlers/compositor.rs`, the placement decision checks the parent first and unconditionally:

```rust
let target = if let Some(p) = &parent {
    // Open dialogs next to their parent window.
    AddWindowTarget::NextTo(p)
} else if let Some(id) = workspace_id {   // <- open-on-workspace lives here
```

`open-on-workspace` is only reached when there is no parent. The single thing that drops the parent link is a rule sending the child to a *different output* — and in the reported setup the hidden workspace and the active workspace are on the same output, so that filter never fires. There was no config-level workaround.

## The fix

A child window now declines to follow its parent onto a hidden workspace, falling through to the window rules and then the active workspace.

This is framed as a correctness fix rather than a new option. A hidden workspace is by definition somewhere the user is deliberately not looking, so placing a dialog there is never what was wanted. The placement code **already** special-cases hidden workspaces on the window-rule path — it declines to activate a window mapped to one (`compositor.rs`, `target_is_hidden`) — so the parent path having no equivalent reads as an oversight rather than a deliberate choice.

Adds `Layout::window_is_on_hidden_workspace`.

## Considered and rejected

A window-rule opt-out such as `open-next-to-parent false` would be more general, but it needs a rule per application and would leave the default behaviour broken for anyone who has not written one. It remains addable later if some app genuinely wants to follow a parent onto a hidden workspace.

## Testing

New test `child_window_does_not_follow_parent_onto_hidden_workspace` reproduces the reported case directly: a parent pinned to a hidden workspace via `open-on-workspace`, and a child that sets its xdg parent before the initial commit, the way a dialog does. It fails on `main` with `child followed its parent onto hidden workspace Some("stash")` and passes with the fix.

Full suite: 308 passing, `cargo fmt --check` clean.

Not verified on hardware — the reporter can confirm against the real 1Password prompt once this is built.
