### PR TITLE
Fix shader initialization on the headless backend

### DIFF
--- a/docs/wiki/Configuration:-Global-Shader.md
+++ b/docs/wiki/Configuration:-Global-Shader.md
@@ -4,7 +4,7 @@ Biri supports a **global post-process shader** that runs over the entire composi
 Use it for effects such as colour grading, CRT scanlines, night-light tints, motion-blur trails, or any full-screen visual transformation.
 
 > [!NOTE]
-> The global shader runs on the **TTY/DRM backend only**.
+> The global shader is available on the **TTY/DRM and headless backends** from startup.
 > It has no effect on the winit (nested/X11) backend.
 > By default, screenshots and screen recordings (screencopy / screencast) render **without** shader effects. See [Shaders in screencast and screenshots](#shaders-in-screencast-and-screenshots) to opt in via `shaders-in-capture`.
 
@@ -734,6 +734,6 @@ When the flag is present, the global shader, all region shaders, and all per-win
 
 ### Scope and Limitations
 
-- **TTY/DRM only.** The effect applies on the real (DRM/KMS) output. It is intentionally **not** applied on the nested winit backend (running niri in a window). By default it is also not applied to screenshots or screen recordings — use [`shaders-in-capture`](#shaders-in-screencast-and-screenshots) to opt in.
+- **TTY/DRM and headless.** The effect is available on both backends from startup. It is intentionally **not** applied on the nested winit backend (running niri in a window). By default it is also not applied to screenshots or screen recordings — use [`shaders-in-capture`](#shaders-in-screencast-and-screenshots) to opt in, including streams from headless outputs.
 - **Output transform.** The effect is verified on outputs with the default (`normal`) transform. On outputs configured with a non-default `transform` (e.g. `90`, `270`, `flipped`), the shader's view of `niri_screen`/`niri_prev` may be mis-oriented. If you use a rotated or flipped output, verify your shader there before relying on it.
 - **Whole-output `global-shader`.** The `global-shader` block applies to all outputs; per-layer global shaders are not supported. For a shader scoped to one output, use a [per-output shader](#per-output-shaders) (`output { shader {} }`); for sub-output scoping, use a [region shader](#region-shaders) (a screen rectangle) or a [per-window shader](#per-window-shaders) (`window-rule { shader {} }`). Multi-pass chains are supported (see [Multi-pass chains](#multi-pass-chains-pass)) but a chain of two or more passes is always whole-output (no `cursor-radius` region mode).

--- a/docs/wiki/Virtual-Outputs.md
+++ b/docs/wiki/Virtual-Outputs.md
@@ -228,12 +228,17 @@ It has a second effect worth knowing: an isolated output is excluded from the
 [consolidated carousel](./Configuration:-Miscellaneous.md#consolidated-carousel), so a virtual
 output does not appear as a cover-flow panel among your physical monitors.
 
-### Shader effects need the TTY backend
+### Shader effects on virtual outputs
 
 The [shader features](./Configuration:-Global-Shader.md) — `global-shader`, `region-shader`,
-per-window `shader {}`, and per-output `shader {}` — apply on the TTY/DRM backend. A virtual output
-created on a TTY session shares that backend's renderer, so shaders work on it like any physical
-output, and a per-output `shader {}` can be attached to a virtual output by name.
+per-window `shader {}`, and per-output `shader {}` — are available on both the TTY/DRM and headless
+backends, including at startup. A per-output `shader {}` can be attached to a virtual output by name.
 
-On the headless backend, shader effects are not active. If you are running a pure headless session
-and expecting a colour filter on the stream, that is why.
+To include shader effects in a Sunshine, wayvnc, or other capture stream, enable
+[`shaders-in-capture`](./Configuration:-Global-Shader.md#shaders-in-screencast-and-screenshots) in your config:
+
+```kdl
+shaders-in-capture true
+```
+
+Capture omits shader effects by default. The Winit backend does not apply shader effects.

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -36,7 +36,7 @@ use smithay::wayland::dmabuf::{DmabufFeedbackBuilder, DmabufGlobal};
 use smithay::wayland::presentation::Refresh;
 
 use super::{virtual_output, IpcOutputMap, OutputId, RenderResult, VirtualOutputMarker};
-use crate::niri::{Niri, RedrawState, State};
+use crate::niri::{global_shader_pass_sources, scoped_shader_chains, Niri, RedrawState, State};
 use crate::render_helpers::{resources, shaders};
 use crate::utils::{get_monotonic_time, logical_output};
 
@@ -106,6 +106,10 @@ impl Headless {
             if let Some(src) = config.animations.window_open.custom_shader.as_deref() {
                 shaders::set_custom_open_program(renderer, Some(src));
             }
+            let passes = global_shader_pass_sources(&config.global_shader);
+            shaders::set_custom_global_passes(renderer, &passes);
+            let chains = scoped_shader_chains(&config);
+            shaders::set_scoped_programs(renderer, &chains);
             drop(config);
 
             niri.update_shaders();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod floating;
 mod fullscreen;
 mod layer_shell;
 mod remove_output;
+mod shaders;
 mod transactions;
 mod virtual_output;
 mod window_opening;

--- a/src/tests/shaders.rs
+++ b/src/tests/shaders.rs
@@ -1,0 +1,90 @@
+use niri_config::Config;
+
+use super::Fixture;
+use crate::render_helpers::shaders::Shaders;
+
+#[test]
+fn egl_headless_shaders_startup_and_reload() {
+    let config = || {
+        Config::parse_mem(
+            r#"
+        global-shader {
+            enable true
+            source "vec4 global_color(vec3 c) { return vec4(1.0); }"
+        }
+        region-shader {
+            geometry x=0 y=0 width=100 height=100
+            source "vec4 global_color(vec3 c) { return vec4(0.1); }"
+        }
+        window-rule {
+            shader {
+                source "vec4 global_color(vec3 c) { return vec4(0.2); }"
+            }
+        }
+        window-shaders {
+            preset "window" {
+                source "vec4 global_color(vec3 c) { return vec4(0.3); }"
+            }
+        }
+        output "headless-1" {
+            shader {
+                source "vec4 global_color(vec3 c) { return vec4(0.4); }"
+            }
+        }
+        output-shaders {
+            preset "output" {
+                source "vec4 global_color(vec3 c) { return vec4(0.5); }"
+            }
+        }
+        "#,
+        )
+        .unwrap()
+    };
+    let mut f = Fixture::with_config(config());
+    let state = f.niri_state();
+    let programs = |renderer: &mut smithay::backend::renderer::gles::GlesRenderer| {
+        let shaders = Shaders::get(renderer);
+        let global = shaders.custom_global_passes.borrow().clone();
+        let scoped = shaders.scoped.borrow().clone();
+        (global, scoped)
+    };
+    let initial = state.backend.with_primary_renderer(programs).unwrap();
+    assert_eq!(initial.0.len(), 1, "global shader must compile at startup");
+    assert_eq!(
+        initial.1.len(),
+        5,
+        "all scoped shaders must compile at startup"
+    );
+    assert!(initial.1.values().all(|chain| chain.len() == 1));
+
+    // ShaderProgram equality checks identity, so this detects recompilation as well as
+    // accidentally adding or dropping programs on an unchanged/unrelated reload.
+    state.reload_config(Ok(config()));
+    assert_eq!(
+        state.backend.with_primary_renderer(programs).unwrap(),
+        initial
+    );
+    let mut changed = config();
+    changed.shaders_in_capture = !changed.shaders_in_capture;
+    // Changing geometry refreshes the scoped registry but should reuse its programs.
+    changed.region_shaders[0].geometry.width = 200.0;
+    state.reload_config(Ok(changed));
+    assert_eq!(
+        state.backend.with_primary_renderer(programs).unwrap(),
+        initial
+    );
+
+    let mut changed = config();
+    changed.global_shader.source =
+        Some("vec4 global_color(vec3 c) { return vec4(0.6); }".to_owned());
+    state.reload_config(Ok(changed));
+    let reloaded = state.backend.with_primary_renderer(programs).unwrap();
+    assert_eq!(reloaded.0.len(), 1);
+    assert_ne!(reloaded.0, initial.0);
+    assert_eq!(reloaded.1, initial.1);
+
+    state.reload_config(Ok(Config::default()));
+    let cleared = state.backend.with_primary_renderer(programs).unwrap();
+    assert!(cleared.0.is_empty());
+    assert!(cleared.1.is_empty());
+}


### PR DESCRIPTION
Headless sessions skipped global and scoped shader compilation at startup, so configured effects were absent until relevant shader settings changed on reload. Initialize these programs alongside the existing animation shaders, using the same source resolution and compilation functions as the TTY backend.

This covers global, region, window, and output shaders, including named presets. Update the shader and virtual-output documentation to describe headless support and the `shaders-in-capture` opt-in for streams.

Fixes #38.

Validation:

- Added an EGL regression test covering startup compilation, program reuse on unchanged reloads and region geometry changes, shader replacement, and removal. Confirmed it failed before the fix and passes afterward.
- All five virtual-output tests pass.
- Real headless sessions captured with grim confirm global, region, and per-output shaders produce red at startup, remain red after an unchanged reload, and turn green after changing the shader source.
- Formatting and diff whitespace checks pass.

Build and tests used `--no-default-features --features dbus,systemd`. The default-feature build is blocked by an unrelated `libspa`/PipeWire binding error (`SPA_ID_INVALID` missing), so portal screencasting was not validated; the live captures use wlr-screencopy.
